### PR TITLE
Add linux build target

### DIFF
--- a/ProtoGen.pro
+++ b/ProtoGen.pro
@@ -111,6 +111,7 @@ unix{
     CONFIG(release, debug|release){
         # Copy key files to the ProtoGenInstall directory
         QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$PWD\exampleprotocol.xml)) $$quote($$shell_path($$PWD\ProtoGenInstall)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$PWD\ProtoGen.sh)) $$quote($$shell_path($$PWD\ProtoGenInstall)) $$escape_expand(\n\t)
         QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$shadowed($$PWD)\ProtoGen)) $$quote($$shell_path($$PWD\ProtoGenInstall)) $$escape_expand(\n\t)
 
         QMAKE_POST_LINK += $$quote(multimarkdown) $$quote($$shell_path($$PWD\README.md)) > $$quote($$shell_path($$PWD\ProtoGenInstall/index.html)) $$escape_expand(\n\t)

--- a/ProtoGen.pro
+++ b/ProtoGen.pro
@@ -107,6 +107,23 @@ macx{
     }
 }
 
+unix{
+    CONFIG(release, debug|release){
+        # Copy key files to the ProtoGenInstall directory
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$PWD\exampleprotocol.xml)) $$quote($$shell_path($$PWD\ProtoGenInstall)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$shadowed($$PWD)\ProtoGen)) $$quote($$shell_path($$PWD\ProtoGenInstall)) $$escape_expand(\n\t)
+
+        QMAKE_POST_LINK += $$quote(multimarkdown) $$quote($$shell_path($$PWD\README.md)) > $$quote($$shell_path($$PWD\ProtoGenInstall/index.html)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$[QT_INSTALL_LIBS]/libQt5Xml.so.5)) $$quote($$shell_path($$PWD/ProtoGenInstall)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$[QT_INSTALL_LIBS]/libQt5Core.so.5)) $$quote($$shell_path($$PWD/ProtoGenInstall)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$[QT_INSTALL_LIBS]/libicudata.so.53)) $$quote($$shell_path($$PWD/ProtoGenInstall)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$[QT_INSTALL_LIBS]/libicui18n.so.53)) $$quote($$shell_path($$PWD/ProtoGenInstall)) $$escape_expand(\n\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$shell_path($$[QT_INSTALL_LIBS]/libicuuc.so.53)) $$quote($$shell_path($$PWD/ProtoGenInstall)) $$escape_expand(\n\t)
+
+        QMAKE_POST_LINK += tar czvf $$quote($$shell_path($$PWD\ProtoGenLinux.tgz)) $$quote($$shell_path($$PWD\ProtoGenInstall)) --exclude=\.svn$$escape_expand(\n\t)
+    }
+}
+
 OTHER_FILES += \
     ProtoGenInstall/ProtoGen.txt \
     exampleprotocol.xml \

--- a/ProtoGen.pro
+++ b/ProtoGen.pro
@@ -4,6 +4,11 @@
 #
 #-------------------------------------------------
 
+contains(QT_VERSION, ^4.*) {
+    message("Cannot build ProtoGen with Qt version $${QT_VERSION}.")
+    error("Use at least Qt 5.0")
+}
+
 QT       += core
 QT       += xml
 

--- a/ProtoGen.sh
+++ b/ProtoGen.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+appname=`basename $0 | sed s,\.sh$,,`
+
+dirname=`dirname $0`
+tmp="${dirname#?}"
+
+if [ "${dirname%$tmp}" != "/" ]; then
+dirname=$PWD/$dirname
+fi
+LD_LIBRARY_PATH=$dirname
+export LD_LIBRARY_PATH
+$dirname/$appname "$@"


### PR DESCRIPTION
Updates to build and deploy for linux. Also, ProtoGen depends on Qt5-specific classes; this includes a fix to prevent head-scratching when presented with mysterious compile errors.