### PR TITLE
LaTeX fix

### DIFF
--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -268,7 +268,7 @@ QString EnumCreator::getMarkdown(QString outline, const QStringList& packetids) 
 
         // The outline paragraph
         if(!outline.isEmpty())
-            output += "## " + outline + ") " + name + "\n\n";
+            output += "## " + name + "\n\n";
 
         // If a longer description exists for this enum, display it in the documentation
         if (!description.isEmpty()) {

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -737,7 +737,7 @@ QString ProtocolPacket::getTopLevelMarkdown(QString outline) const
     QString idvalue = id;
 
     // Put an anchor in the identifier line which is the same as the ID. We'll link to it if we can
-    output += "## " + outline + ") <a name=\"" + id + "\"></a>" + name + "\n";
+    output += "## <a name=\"" + id + "\"></a>" + name + "\n";
     output += "\n";
 
     if(!comment.isEmpty())
@@ -815,7 +815,7 @@ QString ProtocolPacket::getTopLevelMarkdown(QString outline) const
     if(enumList.size() > 0)
     {
         output += "\n";
-        output += "### " + outline + "." + QString().setNum(paragraph++) + ") " + name + " enumerations\n";
+        output += "### " + name + " enumerations\n";
         output += "\n";
 
         for(int i = 0; i < enumList.length(); i++)
@@ -834,7 +834,7 @@ QString ProtocolPacket::getTopLevelMarkdown(QString outline) const
     if(encodables.size() > 0)
     {
         output += "\n";
-        output += "### " + outline + "." + QString().setNum(paragraph++) + ") " + name + " encoding\n";
+        output += "### " + name + " encoding\n";
         output += "\n";
 
         QStringList bytes, names, encodings, repeats, comments;

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1088,6 +1088,7 @@ QString ProtocolParser::getDefaultInlinCSS(void)
         margin-left: auto;\n\
         margin-right: auto;\n\
         font-family:Verdana;\n\
+        counter-reset: h1counter;\
     }\n\
 \n\
     table {\n\
@@ -1113,7 +1114,24 @@ QString ProtocolParser::getDefaultInlinCSS(void)
         font-family: Courier New, monospace;\n\
         font-size: 100%;\n\
         color: darkblue;\n\
-    }\n");
+    }\n\
+    h1:before {\n\
+      content: counter(h1counter) \"\\00a0 \";\n\
+      counter-increment: h1counter;\n\
+      counter-reset: h2counter;\n\
+    }\n\
+    h1 {\n\
+      counter-reset: h2counter;\n\
+    }\n\
+    h2:before {\n\
+      content: counter(h1counter) \".\" counter(h2counter) \"\\00a0 \";\n\
+      counter-increment: h2counter;\n\
+      counter-reset: h3counter;\n\
+    }\n\
+    h3:before {\n\
+      content: counter(h1counter) \".\" counter(h2counter) \".\" counter(h3counter) \"\\00a0 \";\n\
+      counter-increment: h3counter;\n\
+    }");
 
     return inlinecss;
 }

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -833,7 +833,7 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
     file.write("</style>\n");
 
     file.write("\n");
-    file.write("# " + QString().setNum(paragraph1) + ") " + name + " Protocol\n");
+    file.write("# " + name + " Protocol\n");
     file.write("\n");
 
     if(!comment.isEmpty())
@@ -864,7 +864,7 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
     paragraph2 = 1;
     file.write("----------------------------\n\n");
 
-    file.write("# " + QString().setNum(paragraph1) + ") About this ICD\n");
+    file.write("# About this ICD\n");
     file.write("\n");
 
     file.write("This is the interface control document for data *on the wire*, \
@@ -875,7 +875,7 @@ Documentation for software developers (i.e. data *in memory*) is separately prod
 doxygen product, parsing comments embedded in the automatically generated code.\n");
     file.write("\n");
 
-    file.write("# " + QString().setNum(paragraph1) + "." + QString().setNum(paragraph2++) + ") Encodings\n");
+    file.write("# Encodings\n");
     file.write("\n");
 
     file.write("Data can be encoded as unsigned integers, signed integers (two's complement), bitfields, and floating point.\n");
@@ -893,7 +893,7 @@ doxygen product, parsing comments embedded in the automatically generated code.\
 | F64                          | 64 bit floating point (IEEE-754)      | 1 sign bit : 11 exponent bits : 52 significant bits with implied leading 1  |\n");
     file.write("\n");
 
-    file.write("# " + QString().setNum(paragraph1) + "." + QString().setNum(paragraph2++) + ") Size of fields");
+    file.write("# Size of fields");
     file.write("\n");
 
     file.write("The encoding tables give the bytes for each field as X...Y; \
@@ -930,7 +930,7 @@ description column of the table.\n");
             packetids.append(packets.at(i)->getId());
         }
 
-        file.write("# " + QString().setNum(paragraph1) + ") Enumerations\n");
+        file.write("# Enumerations\n");
         file.write("\n");
         file.write(name + " protocol defines these global enumerations.\n");
         file.write("\n");
@@ -953,7 +953,7 @@ description column of the table.\n");
     file.write("----------------------------\n\n");
     if(packets.size() > 0)
     {
-        file.write("# " + QString().setNum(paragraph1) + ") Packets\n");
+        file.write("# Packets\n");
         file.write("\n");
         file.write("This section describes the data payloads of the packets; and how those data are represented in the bytes of the packets.\n");
         file.write("\n");
@@ -982,7 +982,7 @@ description column of the table.\n");
     if(structures.size() > 0)
     {
         paragraph2 = 1;
-        file.write("# " + QString().setNum(paragraph1) + ") Structures");
+        file.write("# Structures");
         file.write("\n");
         file.write(name + " Protocol defines global structures. \
 Structures are similar to packets but are intended to be reusable encodings \

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -816,7 +816,7 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
     file.write("Title: " + name + " Protocol  \n");
 
     //Adding this metadata improves LaTeX support
-    file.write("Base Header Level: 2 \n");
+    file.write("Base Header Level: 1 \n");
     file.write("latex input: mmd-article-begin-doc\n");
 
     file.write("\n");


### PR DESCRIPTION
Latex does not work well with explicitly defined numbering. Also, explicitly numbering each heading defeats some of the usefulness of multimarkdown.

I've made some changes to implement auto-numbering of the sections in the documentation files. 

Why would I even want to do this?

One goal is to have the generated protocol description as a sub-section of an ICD document, which has other sections before it (such as how to encode a CAN packet for a particular device, or the checksum structure on the serial link, for example).

With auto-numbering, we can just parse the output markdown into a larger document and it will keep track of the heading numbers seamlessly.

The changes made to each heading level are pretty transparent.

I also had to make some changes to the default CSS to get the HTML output to play nice. (I found the information for that here - http://www.2ality.com/2012/01/numbering-headingshtml.html)

Let me know what you think!