### PR TITLE
Added <iostream> include so that std::cout is visible

### DIFF
--- a/protocolcode.cpp
+++ b/protocolcode.cpp
@@ -1,5 +1,6 @@
 #include "protocolcode.h"
 #include "protocolparser.h"
+#include <iostream>
 
 /*!
  * Construct a blank protocol field


### PR DESCRIPTION
Without the line *#include <<iostream>>* the build errors with:

`'cout' is not a member of std`