### PR TITLE
Fixed bug with custom '-docs' directory argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ ProtoGenWin.zip
 ProtoGenMac.zip
 release/
 debug/
+Makefile**
+*.Debug
+*.Release
+*.tmp

--- a/main.cpp
+++ b/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
                 QString docs = ProtocolFile::sanitizePath(arguments.at(++i));
 
                 // If the directory already exists, or we can make it, then use it
-                if(QDir::current().mkdir(docs))
+                if(QDir(docs).exists() ||  QDir::current().mkdir(docs))
                     parser.setDocsPath(docs);
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
             if (arguments.size() > (i + 1))
             {
                 // The following argument is the directory path for documents
-                QString docs = ProtocolFile::sanitizePath(arguments.at(i++));
+                QString docs = ProtocolFile::sanitizePath(arguments.at(++i));
 
                 // If the directory already exists, or we can make it, then use it
                 if(QDir::current().mkdir(docs))


### PR DESCRIPTION
* Argument parsing was failing to correctly grab the -docs directory due to the way that iterator 'i' was being incremented. Fixed!

* Added some more generated files to .gitignore