### PR TITLE
More options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ ProtoGen is a C++/Qt5 compiled command line application, suitable for inclusion 
 
 - `-latex` will cause ProtoGen to generate LaTeX style markdown (if multimarkdown is installed and in the PATH).
 
+- `-latex-header-level level` specifies the starting header-level for generated LaTeX output. If unspecified, it defaults to `1` (Chapter headings)
+
 - `-no-doxygen` will cause ProtoGen to skip the output of the developer level html documentation. 
 
 - `-no-markdown` will cause ProtoGen to skip the output of the user level html documentation. 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ ProtoGen is a C++/Qt5 compiled command line application, suitable for inclusion 
 
 - `-docs dir` specifies a separate directory for the documentation markdown to be written. If `-docs dir` is not specified, documentation markdown will be written to the same same directory as `Outputpath`.
 
+- `-show-hidden-items` will cause documentation to be generated for **all** elements, even if the element has the *hidden="true"* flag
+
 - `-latex` will cause ProtoGen to generate LaTeX style markdown (if multimarkdown is installed and in the PATH).
 
 - `-latex-header-level level` specifies the starting header-level for generated LaTeX output. If unspecified, it defaults to `1` (Chapter headings)

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
     if(arguments.size() <= 1)
     {
         std::cout << "Protocol generator usage:" << std::endl;
-        std::cout << "ProtoGen input.xml [outputpath] [-docs docspath] [-latex] [-latex-header-level level] [-no-doxygen] [-no-markdown] [-no-helper-files] [-no-unrecognized-warnings]" << std::endl;
+        std::cout << "ProtoGen input.xml [outputpath] [-docs docspath] [-show-hidden-items] [-latex] [-latex-header-level level] [-no-doxygen] [-no-markdown] [-no-helper-files] [-no-unrecognized-warnings]" << std::endl;
         return 2;   // no input file
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
             parser.disableMarkdown(true);
         else if(arg.contains("-no-helper-files", Qt::CaseInsensitive))
             parser.disableHelperFiles(true);
+        else if (arg.contains("-show-hidden-items", Qt::CaseInsensitive))
+            parser.showHiddenItems(true);
         else if(arg.endsWith(".xml"))
             filename = arg;
         else if (arg.startsWith("-latex-header-level"))

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
     if(arguments.size() <= 1)
     {
         std::cout << "Protocol generator usage:" << std::endl;
-        std::cout << "ProtoGen input.xml [outputpath] [-docs docspath] [-latex] [-no-doxygen] [-no-markdown] [-no-helper-files] [-no-unrecognized-warnings]" << std::endl;
+        std::cout << "ProtoGen input.xml [outputpath] [-docs docspath] [-latex] [-latex-header-level level] [-no-doxygen] [-no-markdown] [-no-helper-files] [-no-unrecognized-warnings]" << std::endl;
         return 2;   // no input file
     }
 
@@ -42,6 +42,29 @@ int main(int argc, char *argv[])
             parser.disableHelperFiles(true);
         else if(arg.endsWith(".xml"))
             filename = arg;
+        else if (arg.startsWith("-latex-header-level"))
+        {
+            // Is there an argument following this one?
+            if (arguments.size() > (i + 1))
+            {
+                // Read the header-level and parse the header level (and auto-increment the argument index)
+                QString lvl = arguments.at(++i);
+
+                bool ok = false;
+
+                int header_level = lvl.toInt(&ok);
+
+                if (!ok)
+                {
+                    std::cerr << "warning: -latex-header-level argument '" << lvl.toStdString() << "' is invalid.";
+                }
+
+                else if (header_level > 0)
+                {
+                    parser.setLaTeXLevel(header_level);
+                }
+            }
+        }
         else if (arg.contains("-latex", Qt::CaseInsensitive))
             parser.setLaTeXSupport(true);
         else if (arg.contains("-no-unrecognized-warnings", Qt::CaseInsensitive))

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -483,17 +483,17 @@ void ProtocolField::parse(void)
         else if(attrname.compare("Units", Qt::CaseInsensitive) == 0)
         {
             extraInfoNames.append("Units");
-            extraInfoValues.append(attr.value().toLower());
+            extraInfoValues.append(attr.value());
         }
         else if(attrname.compare("Range", Qt::CaseInsensitive) == 0)
         {
             extraInfoNames.append("Range");
-            extraInfoValues.append(attr.value().toLower());
+            extraInfoValues.append(attr.value());
         }
         else if(attrname.compare("Notes", Qt::CaseInsensitive) == 0)
         {
             extraInfoNames.append("Notes");
-            extraInfoValues.append(attr.value().toLower());
+            extraInfoValues.append(attr.value());
         }
         else if(support.disableunrecognized == false)
         {
@@ -1301,9 +1301,9 @@ void ProtocolField::getDocumentationDetails(QList<int>& outline, QString& startB
             else
             {
                 if(encodedType.isBitfield)
-                    description += "reserved bits in the packet.";
+                    description += "Reserved bits in the packet.";
                 else
-                    description += "reserved bytes in the packet.";
+                    description += "Reserved bytes in the packet.";
             }
         }
         else

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -919,15 +919,8 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
 
     ProtocolFile file(filename, false);
 
-    // Adding this metadata improves LaTeX support
-    file.write("latex input: mmd-article-header \n");
-
-    // Metadata must appear at the top
-    file.write("Title: " + name + " Protocol  \n");
-
-    // Adding this metadata improves LaTeX support
-    file.write("Base Header Level: 1 \n");
-    file.write("latex input: mmd-article-begin-doc\n");
+    file.write("Base Header Level: 1 \n");  //Base header level refers to the HTML output format
+    file.write("LaTeX Header Level: 3 \n"); //Header-level 3 ensures that the LaTeX document starts at the "Section" level
 
     file.write("\n");
 

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -23,6 +23,7 @@ const QString ProtocolParser::genVersion = "1.5.3.b";
  * \brief ProtocolParser::ProtocolParser
  */
 ProtocolParser::ProtocolParser() :
+    latexHeader(1),
     latexEnabled(false),
     nomarkdown(false),
     nohelperfiles(false),
@@ -919,8 +920,8 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
 
     ProtocolFile file(filename, false);
 
-    file.write("Base Header Level: 1 \n");  //Base header level refers to the HTML output format
-    file.write("LaTeX Header Level: 3 \n"); //Header-level 3 ensures that the LaTeX document starts at the "Section" level
+    file.write("Base Header Level: 1 \n");  // Base header level refers to the HTML output format
+    file.write("LaTeX Header Level: " + QString::number(latexHeader) + " \n"); // LaTeX header level can be set by user
 
     file.write("\n");
 

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -27,7 +27,8 @@ ProtocolParser::ProtocolParser() :
     latexEnabled(false),
     nomarkdown(false),
     nohelperfiles(false),
-    nodoxygen(false)
+    nodoxygen(false),
+    showAllItems(false)
 {
 }
 
@@ -970,7 +971,7 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
             continue;
 
         // If the particular documention is to be hidden
-        if(alldocumentsinorder.at(i)->isHidden())
+        if(alldocumentsinorder.at(i)->isHidden() && !showAllItems)
             continue;
 
         file.write(alldocumentsinorder.at(i)->getTopLevelMarkdown(true, packetids));

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -23,6 +23,9 @@ public:
     //! Set LaTeX support
     void setLaTeXSupport(bool on) {latexEnabled = on;}
 
+    //! Set LaTeX header level
+    void setLaTeXLevel(int level) {latexHeader = level;}
+
     //! Option to disable markdown output
     void disableMarkdown(bool disable) {nomarkdown = disable;}
 
@@ -139,6 +142,7 @@ protected:
 
     QString docsDir;    //!< Directory target for storing documentation markdown
 
+    int latexHeader;    //!< Top heading level for LaTeX output
     bool latexEnabled;  //!< Generate LaTeX markdown automagically
     bool nomarkdown;    //!< Disable markdown output
     bool nohelperfiles; //!< Disable helper file output

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -35,6 +35,9 @@ public:
     //! Option to disable doxygen output
     void disableDoxygen(bool disable) {nodoxygen = disable;}
 
+    //! Option to force documentation for hidden items
+    void showHiddenItems(bool show) {showAllItems = show;}
+
     //! Option to disable unrecognized warnings
     void disableUnrecognizedWarnings(bool disable) {support.disableunrecognized = disable;}
 
@@ -147,6 +150,7 @@ protected:
     bool nomarkdown;    //!< Disable markdown output
     bool nohelperfiles; //!< Disable helper file output
     bool nodoxygen;     //!< Disable doxygen output
+    bool showAllItems;  //!< Generate documentation even for elements with 'hidden="true"'
     QString inlinecss;  //!< CSS used for markdown output
 
     QList<ProtocolDocumentation*> alldocumentsinorder;


### PR DESCRIPTION
This PR adds two more command-line options:

* The `-latex-header-level` flag allows specification of the LaTeX header level which greatly improves the flexibility of generated LaTeX output from multimarkdown
* The `-show-hidden-items` forces documentation generation for all elements, even if the *hidden="true"* flag is set for a given element