### PR TITLE
Added ability to provide prefix to each element in an enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ Enum tag
 
 The Enum tag is used to create a named C language typedef enumeration. The enumeration is typically created in the header file that represents the parent of this tag. An example Enum tag is:
 
-    <Enum name="packetIds" comment="The list of packet identifiers">
+    <Enum name="packetIds" prefix="PKT_" comment="The list of packet identifiers">
         <Value name="ENGINECOMMAND" value="10" comment="Engine command packet"/>
         <Value name="ENGINESETTINGS" comment="Engine settings packet"/>
         <Value name="THROTTLESETTINGS" comment="Throttle settings packet"/>
-        <Value name="VERSION" value="20" comment="Version reporting packet"/>
+        <Value name="VERSION" ignorePrefix="true" value="20" comment="Version reporting packet"/>
         <Value name="TELEMETRY" comment="Regular elemetry packet"/>
     </Enum>
 
@@ -179,11 +179,11 @@ which produces this output:
      */
     typedef enum
     {
-        ENGINECOMMAND = 10,  //!< Engine command packet
-        ENGINESETTINGS,      //!< Engine settings packet
-        THROTTLESETTINGS,    //!< Throttle settings packet
+        PKT_ENGINECOMMAND = 10,  //!< Engine command packet
+        PKT_ENGINESETTINGS,      //!< Engine settings packet
+        PKT_THROTTLESETTINGS,    //!< Throttle settings packet
         VERSION = 20,        //!< Version reporting packet
-        TELEMETRY            //!< Regular elemetry packet
+        PKT_TELEMETRY            //!< Regular elemetry packet
     }packetIds;
 
 Enum tag attributes:
@@ -194,9 +194,11 @@ Enum tag attributes:
 
 - `comment` : Gives a multi-line line doxygen comment wrapped at 80 characters that appears above the enumeration.
 
+- `prefix` : Gives a string that will be prefixed to the name of each element within the enumeration.
+
 - `description` : If provided, a long-form description can be prepended to the given enumeration (in the documentation markdown). This allows for a more verbose description of the particular enumeration to be added to the docs. NOTE: This description will *not* appear in the generated code.
 
-- `hidden` : is used to specify that this particular enumeration will *not* appear in the generated documentation markdown. NOTE: This enumeartion will still appear in the generated code.
+- `hidden` : is used to specify that this particular enumeration will *not* appear in the generated documentation markdown. NOTE: This enumeration will still appear in the generated code.
 
 ###Enum : Value subtag attributes:
 
@@ -207,6 +209,8 @@ The Enum tag supports Value subtags; which are used to name individual elements 
 - `value` : is an optional attribute that sets the value of this enumeration element. If value is left out the element will get its value in the normal C language way (by incrementing from the previous element, or starting at 0). Note that non numeric values may be used, as long as those strings are resolved by an include directive or previous enumeration.
 
 - `comment` : gives a one line doxygen comment that follows the enumeration element.
+
+- `ignorePrefix` : is used to specify that this particular enumeartion element will *not* be assigned a prefix (if a prefix is specifed for this enumeration).
 
 - `hidden` : is used to specify that this particular enumeration element will *not* appear in the generated documentation markdown.
 

--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -30,6 +30,7 @@ void EnumCreator::clear(void)
     description.clear();
     output.clear();
     nameList.clear();
+    prefix.clear();
     commentList.clear();
     valueList.clear();
     numberList.clear();
@@ -93,19 +94,22 @@ void EnumCreator::parse(void)
             continue;
 
         QString attrname = attr.name();
+        QString attrval = attr.value().trimmed();
 
         if(attrname.compare("name", Qt::CaseInsensitive) == 0)
-            name = attr.value().trimmed();
+            name = attrval;
         else if(attrname.compare("comment", Qt::CaseInsensitive) == 0)
             comment = ProtocolParser::reflowComment(attr.value());
         else if(attrname.compare("description", Qt::CaseInsensitive) == 0)
-            description = attr.value().trimmed();
+            description = attrval;
         else if(attrname.compare("hidden", Qt::CaseInsensitive) == 0)
-            hidden = ProtocolParser::isFieldSet(attr.value().trimmed());
+            hidden = ProtocolParser::isFieldSet(attrval);
+        else if(attrname.compare("prefix", Qt::CaseInsensitive) == 0)
+            prefix = attrval;
         else if(isglobal && attrname.compare("file", Qt::CaseInsensitive) == 0)
         {
             // Remove the extension if any
-            file = attr.value().trimmed();
+            file = attrval;
             file = file.left(file.indexOf("."));
         }
         else if(support.disableunrecognized == false)
@@ -143,6 +147,7 @@ void EnumCreator::parse(void)
         QString value;
         QString comment;
         bool hiddenvalue = false;
+        bool ignorePrefix = false;
 
         for(int i = 0; i < map.count(); i++)
         {
@@ -151,17 +156,26 @@ void EnumCreator::parse(void)
                 continue;
 
             QString attrname = attr.name();
+            QString attrval = attr.value().trimmed();
 
             if(attrname.compare("name", Qt::CaseInsensitive) == 0)
-                valueName = attr.value().trimmed();
+                valueName = attrval;
             else if(attrname.compare("value", Qt::CaseInsensitive) == 0)
-                value = attr.value().trimmed();
+                value = attrval;
             else if(attrname.compare("comment", Qt::CaseInsensitive) == 0)
                 comment = ProtocolParser::reflowComment(attr.value());
             else if(attrname.compare("hidden", Qt::CaseInsensitive) == 0)
-                hiddenvalue = ProtocolParser::isFieldSet(attr.value().trimmed());
+                hiddenvalue = ProtocolParser::isFieldSet(attrval);
+            else if(attrname.compare("ignorePrefix", Qt::CaseInsensitive) == 0)
+                ignorePrefix = ProtocolParser::isFieldSet(attrval);
             else if(support.disableunrecognized == false)
                 emitWarning(":" + valueName + ": Unrecognized attribute: " + attrname);
+        }
+
+        // Add the enum prefix if applicable
+        if ( !prefix.isEmpty() && !ignorePrefix )
+        {
+            valueName = prefix + valueName;
         }
 
         // Add it to our list

--- a/enumcreator.h
+++ b/enumcreator.h
@@ -95,6 +95,9 @@ protected:
     //! A longer description is possible for enums (will be displayed in the documentation)
     QString description;
 
+    //! A prefix can be specified for each element in the enum
+    QString prefix;
+
     //! The header file output string of the enumeration
     QString output;
 


### PR DESCRIPTION
* Added `prefix` tag to enum structure
* Added `ignorePrefix` tag to enum
* Added documentation

This PR adds the ability to specify a "prefix" for an enum structure, which then gets added to each element within the enumeration.

There is also some (minor) cleanup of associated code.