### PR TITLE
Changed div-by-8 to rs-by-3

### DIFF
--- a/protocolbitfield.cpp
+++ b/protocolbitfield.cpp
@@ -177,7 +177,7 @@ void encodeBitfield(unsigned int value, uint8_t* bytes, int* index, int* bitcoun
     int bitoffset = (*bitcount) + numbits;\n\
 \n\
     // The byte offset of the least significant block of 8 bits to move\n\
-    int byteoffset = (bitoffset-1)/8;\n\
+    int byteoffset = (bitoffset-1) >> 3;\n\
 \n\
     // The remainder bits (modulo 8) which are the least significant bits to move\n\
     int remainder = bitoffset & 0x07;\n\


### PR DESCRIPTION
The PIC18 compiler (read, POS) does not optimize out the divide-by-8 in the bitfieldspecial.c routine.

Replacing `/8` with `>>3` results in a performance boost for the PIC compiler of 60%.

@billvaglienti can you see any issues with this in general? Slightly reduces code readability but enforces good behavior by the compiler.