### PR TITLE
Added "pktPrefix" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The Protocol tag supports the following attributes:
 
 - `prefix` : A string that can be used to prepend structure and file names. This is typically left out, but if a single project uses multiple ProtoGen protocols then it may be useful to give them different prefixes to avoid namespace collisions.
 
+- `pktPrefix` : A string that can be used to prepend default packet ID values, if no ID is explicitly specified for a given packet.
+
 - `maxSize` : A number that specifies the maximum number of data bytes that a packet can support. If this is provided, and is greater than zero, ProtoGen will issue a warning for any packet whose maximum encoded size is greater than this.
 
 - `api` : An enumeration that can be used to determine API compatibility. Changes to the protocol definition that break backwards compatibility should increment this value. Calling code can access the api value and use it to (for example) seed a packet checksum/CRC to prevent clashes with different versions of the protocol.
@@ -286,7 +288,7 @@ Packet tag attributes:
   
 - `name` : The same as the name attribute of a structure.
 
-- `ID` : gives the identifying value of the packet. This can be any resolvable string, though typically it will be an element of an enumeration. If the ID attribute is missing the all-caps name of the packet is used as the ID. In some cases multiple packets may be identical except for the identifier. It is possible to simply define multiple packets in the XML, however a better solution is to specify multiple identifiers by using spaces or commas to delimit the identifers in the ID attribute. If multiple identifiers are given the encode function is changed so the caller provides the desired id. In addition the decode function is changed so that any of the given identifiers can be used for a successful packet decode.
+- `ID` : gives the identifying value of the packet. This can be any resolvable string, though typically it will be an element of an enumeration. If the ID attribute is missing the all-caps name of the packet is used as the default ID. *If the <Protocol> tag defines the `pktPrefix` attribute, this is prepended to the default ID name*. In some cases multiple packets may be identical except for the identifier. It is possible to simply define multiple packets in the XML, however a better solution is to specify multiple identifiers by using spaces or commas to delimit the identifers in the ID attribute. If multiple identifiers are given the encode function is changed so the caller provides the desired id. In addition the decode function is changed so that any of the given identifiers can be used for a successful packet decode.
 
 - `file` : The same as the file attribute of a structure.
 

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -283,7 +283,7 @@ void ProtocolPacket::createUtilityFunctions(const QDomElement& e)
     // If no ID is supplied then use the packet name in upper case,
     // assuming that the user will define it elsewhere
     if(ids.count() <= 0)
-        ids.append(name.toUpper());
+        ids.append( support.pktPrefix +  name.toUpper());
 
     for(int i = 0; i < ids.count(); i++)
     {

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -64,6 +64,9 @@ void ProtocolSupport::parse(const QDomNamedNodeMap& map)
     // Prefix is not required
     prefix = ProtocolParser::getAttribute("prefix", map);
 
+    // Packet prefix is not required
+    pktPrefix = ProtocolParser::getAttribute("pktPrefix", map ).toUpper();
+
     // Packet name post fixes
     packetStructureSuffix = ProtocolParser::getAttribute("packetStructureSuffix", map, packetStructureSuffix);
     packetParameterSuffix = ProtocolParser::getAttribute("packetParameterSuffix", map, packetParameterSuffix);

--- a/protocolsupport.h
+++ b/protocolsupport.h
@@ -30,6 +30,7 @@ public:
     QString packetParameterSuffix;  //!< Name to use at end of encode/decode Packet parameter functions
     QString protoName;              //!< Name of the protocol
     QString prefix;                 //!< Prefix name
+    QString pktPrefix;              //!< Packet prefix name
 };
 
 #endif // PROTOCOLSUPPORT_H


### PR DESCRIPTION
For the purposes of "shorthand" I have added the `pktPrefix` property to the <Protocol> tag. The purpose of this parameter is to add a common prefix for packet ID values (but only where an ID value is not explicitly specified).

e.g.

```
<Protocol name="ProtocolName" pktPrefix="PROTOCOL_PKT_">
<Packet name="GPS_Data">
<Data ... />
</Packet>
</Protocol>
```

will produce a packet with name _ProcotolName_ and ID _PROTOCOL_PKT_GPS_DATA_

If the pktPrefix parameter is not defined then there will be no change to generated code.