### PR TITLE
Subfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ Makefile**
 *.Release
 *.tmp
 ProtoGenMac.tgz
--build-*/
+build-*/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Makefile**
 *.Release
 *.tmp
 ProtoGenMac.tgz
+-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ ProtoGenWin.zip
 ProtoGenMac.zip
 release/
 debug/
-MakeFile
+MakeFile**
 *.Debug
 *.Release
+*.tmp
+ProtoGenMac.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,6 @@ ProtoGenWin.zip
 ProtoGenMac.zip
 release/
 debug/
-Makefile**
+MakeFile
 *.Debug
 *.Release
-*.tmp
-ProtoGenMac.tgz
-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ ProtoGenWin.zip
 ProtoGenMac.zip
 release/
 debug/
-MakeFile**
+Makefile**
 *.Debug
 *.Release
 *.tmp

--- a/README.md
+++ b/README.md
@@ -142,10 +142,25 @@ By default protogen will output a protocol header file; and a header and source 
 
 The `file` attribute can include path information (for example "src/protogen/filename"). If path information is provided it is assumed to be relative to the global output path, unless the path information is absolute. Path information is only used in the creation of the file; any include directive which references a file will not include the path information.
 
+Require tag
+-----------
+
+The Require tag is used to insert XML from an external protocol file at the specified location. The generated code will be structued as if the linked xml was written *at the location it is called* - this tag provides a convenience function for separating the procotol definition into multiple files.
+
+In addition to allowing the protocol to be defined in multiple files, this functionality allows for common features to be inserted into multiple protocol files.
+
+    <Require file="..\version.xml"/>
+    
+The Require tag supports the following attributes:
+
+- `file` : gives the name of the file to insert, relative to the path of the file which requires it. 
+
+The included file must follow the same structure requirements as the base protocol file. However, any top-level attributes specified in the included file (i.e. in the `Protocol` tag) will be ignored.
+
 Include tag
 -----------
 
-The Include tag is used to include other files in the generated code by emmitting a C preprocessor `#include` directive. If the Include tag is a direct child of the Protocol tag then it is emitted in the main header file. If it is a direct child of a Packet or Structure tag then it is emitted in the packet or structures header file. An example Include tag is:
+The Include tag is used to include external C header files in the generated code using a C preprocessor `#include` directive. If the Include tag is a direct child of the Protocol tag then it is emitted in the main header file. If it is a direct child of a Packet or Structure tag then it is emitted in the packet or structures header file. An example Include tag is:
 
     <Include name="indices.h" comment="indices.h is included for array length enumerations"/>
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The Require tag is used to insert XML from an external protocol file at the spec
 
 In addition to allowing the protocol to be defined in multiple files, this functionality allows for common features to be inserted into multiple protocol files.
 
-    <Require file="..\version.xml"/>
+    <Require file="../version.xml"/>
     
 The Require tag supports the following attributes:
 

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -52,6 +52,9 @@ public:
     //! Parse the DOM from the xml file. This kicks off the auto code generation for the protocol
     bool parse(QString filename, QString path);
 
+    //! Parse a single XML file within the file heirarchy
+    bool parseFile(QString xmlFilename, bool onlyParseStructs = false);
+
     //! Get the line number from a hierarchical name
     int getLineNumber(const QString& hierarchicalName) {return line.getLineNumber(hierarchicalName);}
 


### PR DESCRIPTION
This PR adds the ability to split the protocol definition into multiple .xml files. 

The <Require> tag is used to include files, with relative directory support e.g. `<Require file="../version.xml"/>`

Full documentation provided in [README.md](https://github.com/SchrodingersGat/ProtoGen/blob/subfiles/README.md#require-tag)
