### PR TITLE
Packet pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The Protocol tag supports the following attributes:
 
 - `comment` : The comment for the Protocol tag will be placed at the top of the main header file as a multi-line doxygen comment with a \mainpage tag.
 
+- `pointer` : By default, the generated code does not know about the structure of the packet datatype, and uses generic pointers (void*) to reference packet data. This behaviour can be overridden by specifying the datatype of the packet. If this parameter is specified, the protocol file must include the header file where the packet is defined.
+
 Comments
 --------
 

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -341,6 +341,10 @@ void ProtocolPacket::createStructurePacketFunctions(void)
     int numEncodes = getNumberOfEncodeParameters();
     int numDecodes = getNumberOfDecodeParameters();
 
+    // Helper strings to prevent code repetition
+    const QString PKT_ENCODE = VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt";
+    const QString PKT_DECODE = INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt";
+
     if(encode)
     {
         // The prototype for the packet encode function
@@ -349,16 +353,16 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         if(numEncodes > 0)
         {
             if(ids.count() <= 1)
-                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user);\n");
+                header.write(PKT_ENCODE + ", const " + typeName + "* user);\n");
             else
-                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user, uint32_t id);\n");
+                header.write(PKT_ENCODE + ", const " + typeName + "* user, uint32_t id);\n");
         }
         else
         {
             if(ids.count() <= 1)
-                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt);\n");
+                header.write(PKT_ENCODE + ");\n");
             else
-                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, uint32_t id);\n");
+                header.write(PKT_ENCODE + ", uint32_t id);\n");
         }
     }
 
@@ -369,9 +373,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         header.write("//! " + getPacketDecodeBriefComment() + "\n");
 
         if(numDecodes > 0)
-            header.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt, " + typeName + "* user);\n");
+            header.write(PKT_DECODE + ", " + typeName + "* user);\n");
         else
-            header.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt);\n");
+            header.write(PKT_DECODE + ");\n");
     }
 
     if(encode)
@@ -390,13 +394,13 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if(ids.count() <= 1)
             {
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user)\n");
+                source.write(PKT_ENCODE + ", const " + typeName + "* user)\n");
             }
             else
             {
                 source.write(" * \\param id is the packet identifier for pkt\n");
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user, uint32_t id)\n");
+                source.write(PKT_ENCODE + ", const " + typeName + "* user, uint32_t id)\n");
             }
             source.write("{\n");
         }
@@ -405,13 +409,13 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if(ids.count() <= 1)
             {
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt)\n");
+                source.write(PKT_ENCODE + ")\n");
             }
             else
             {
                 source.write(" * \\param id is the packet identifier for pkt\n");
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, uint32_t id)\n");
+                source.write(PKT_ENCODE + ", uint32_t id)\n");
             }
             source.write("{\n");
         }
@@ -469,9 +473,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write(" * \\return 0 is returned if the packet ID or size is wrong, else 1\n");
             source.write(" */\n");
             if(numDecodes > 0)
-                source.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt pkt, " + typeName + "* user)\n");
+                source.write(PKT_DECODE + " pkt, " + typeName + "* user)\n");
             else
-                source.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt)\n");
+                source.write(PKT_DECODE + ")\n");
             source.write("{\n");
             source.write(TAB_IN + "int numBytes;\n");
             source.write(TAB_IN + "int byteindex = 0;\n");
@@ -574,7 +578,7 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write(" * \\param pkt points to the packet being decoded by this function\n");
             source.write(" * \\return 0 is returned if the packet ID is wrong, else 1\n");
             source.write(" */\n");
-            source.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt)\n");
+            source.write(PKT_DECODE + ")\n");
             source.write("{\n");
             if(ids.count() <= 1)
             {

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -43,7 +43,6 @@ ProtocolPacket::~ProtocolPacket(void)
     clear();
 }
 
-
 /*!
  * Clear out any data, resetting for next packet parse operation
  */
@@ -350,16 +349,16 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         if(numEncodes > 0)
         {
             if(ids.count() <= 1)
-                header.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user);\n");
+                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user);\n");
             else
-                header.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user, uint32_t id);\n");
+                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user, uint32_t id);\n");
         }
         else
         {
             if(ids.count() <= 1)
-                header.write(VOID_ENCODE + extendedName() + "(void* pkt);\n");
+                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt);\n");
             else
-                header.write(VOID_ENCODE + extendedName() + "(void* pkt, uint32_t id);\n");
+                header.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, uint32_t id);\n");
         }
     }
 
@@ -370,9 +369,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         header.write("//! " + getPacketDecodeBriefComment() + "\n");
 
         if(numDecodes > 0)
-            header.write(INT_DECODE + extendedName() + "(const void* pkt, " + typeName + "* user);\n");
+            header.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt, " + typeName + "* user);\n");
         else
-            header.write(INT_DECODE + extendedName() + "(const void* pkt);\n");
+            header.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt);\n");
     }
 
     if(encode)
@@ -391,13 +390,13 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if(ids.count() <= 1)
             {
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user)\n");
+                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user)\n");
             }
             else
             {
                 source.write(" * \\param id is the packet identifier for pkt\n");
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user, uint32_t id)\n");
+                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, const " + typeName + "* user, uint32_t id)\n");
             }
             source.write("{\n");
         }
@@ -406,13 +405,13 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if(ids.count() <= 1)
             {
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(void* pkt)\n");
+                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt)\n");
             }
             else
             {
                 source.write(" * \\param id is the packet identifier for pkt\n");
                 source.write(" */\n");
-                source.write(VOID_ENCODE + extendedName() + "(void* pkt, uint32_t id)\n");
+                source.write(VOID_ENCODE + extendedName() + "(" + support.pointerType + " pkt, uint32_t id)\n");
             }
             source.write("{\n");
         }
@@ -470,9 +469,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write(" * \\return 0 is returned if the packet ID or size is wrong, else 1\n");
             source.write(" */\n");
             if(numDecodes > 0)
-                source.write(INT_DECODE + extendedName() + "(const void* pkt, " + typeName + "* user)\n");
+                source.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt pkt, " + typeName + "* user)\n");
             else
-                source.write(INT_DECODE + extendedName() + "(const void* pkt)\n");
+                source.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt)\n");
             source.write("{\n");
             source.write(TAB_IN + "int numBytes;\n");
             source.write(TAB_IN + "int byteindex = 0;\n");
@@ -575,7 +574,7 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write(" * \\param pkt points to the packet being decoded by this function\n");
             source.write(" * \\return 0 is returned if the packet ID is wrong, else 1\n");
             source.write(" */\n");
-            source.write(INT_DECODE + extendedName() + "(const void* pkt)\n");
+            source.write(INT_DECODE + extendedName() + "(const " + support.pointerType + " pkt)\n");
             source.write("{\n");
             if(ids.count() <= 1)
             {
@@ -825,7 +824,7 @@ void ProtocolPacket::createPacketFunctions(void)
  */
 QString ProtocolPacket::getPacketEncodeSignature(void) const
 {
-    QString output = VOID_ENCODE + support.prefix + name + support.packetParameterSuffix + "(void* pkt";
+    QString output = VOID_ENCODE + support.prefix + name + support.packetParameterSuffix + "(" + support.pointerType + " pkt";
 
     output += getDataEncodeParameterList();
 
@@ -843,7 +842,7 @@ QString ProtocolPacket::getPacketEncodeSignature(void) const
  */
 QString ProtocolPacket::getPacketDecodeSignature(void) const
 {
-    QString output = INT_DECODE + support.prefix + name + support.packetParameterSuffix + "(const void* pkt";
+    QString output = INT_DECODE + support.prefix + name + support.packetParameterSuffix + "(const " + support.pointerType + " pkt";
 
     output += getDataDecodeParameterList() + ")";
 

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -10,6 +10,14 @@
 #include <QStringList>
 #include <iostream>
 
+/*
+ * Constant string defines that are re-used often
+ * Encoding them as constant values prevents typo mistakes
+ * and copying errors
+ */
+
+const QString VOID_ENCODE = "void encode";
+const QString INT_DECODE = "int decode";
 
 /*!
  * Construct the object that parses packet descriptions
@@ -340,16 +348,16 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         if(numEncodes > 0)
         {
             if(ids.count() <= 1)
-                header.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt, const " + typeName + "* user);\n");
+                header.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user);\n");
             else
-                header.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt, const " + typeName + "* user, uint32_t id);\n");
+                header.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user, uint32_t id);\n");
         }
         else
         {
             if(ids.count() <= 1)
-                header.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt);\n");
+                header.write(VOID_ENCODE + extendedName() + "(void* pkt);\n");
             else
-                header.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt, uint32_t id);\n");
+                header.write(VOID_ENCODE + extendedName() + "(void* pkt, uint32_t id);\n");
         }
     }
 
@@ -360,9 +368,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         header.write("//! " + getPacketDecodeBriefComment() + "\n");
 
         if(numDecodes > 0)
-            header.write("int decode" + support.prefix + name + support.packetStructureSuffix + "(const void* pkt, " + typeName + "* user);\n");
+            header.write(INT_DECODE + extendedName() + "(const void* pkt, " + typeName + "* user);\n");
         else
-            header.write("int decode" + support.prefix + name + support.packetStructureSuffix + "(const void* pkt);\n");
+            header.write(INT_DECODE + extendedName() + "(const void* pkt);\n");
     }
 
     if(encode)
@@ -381,13 +389,13 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if(ids.count() <= 1)
             {
                 source.write(" */\n");
-                source.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt, const " + typeName + "* user)\n");
+                source.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user)\n");
             }
             else
             {
                 source.write(" * \\param id is the packet identifier for pkt\n");
                 source.write(" */\n");
-                source.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt, const " + typeName + "* user, uint32_t id)\n");
+                source.write(VOID_ENCODE + extendedName() + "(void* pkt, const " + typeName + "* user, uint32_t id)\n");
             }
             source.write("{\n");
         }
@@ -396,13 +404,13 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if(ids.count() <= 1)
             {
                 source.write(" */\n");
-                source.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt)\n");
+                source.write(VOID_ENCODE + extendedName() + "(void* pkt)\n");
             }
             else
             {
                 source.write(" * \\param id is the packet identifier for pkt\n");
                 source.write(" */\n");
-                source.write("void encode" + support.prefix + name + support.packetStructureSuffix + "(void* pkt, uint32_t id)\n");
+                source.write(VOID_ENCODE + extendedName() + "(void* pkt, uint32_t id)\n");
             }
             source.write("{\n");
         }
@@ -460,9 +468,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write(" * \\return 0 is returned if the packet ID or size is wrong, else 1\n");
             source.write(" */\n");
             if(numDecodes > 0)
-                source.write("int decode" + support.prefix + name + support.packetStructureSuffix + "(const void* pkt, " + typeName + "* user)\n");
+                source.write(INT_DECODE + extendedName() + "(const void* pkt, " + typeName + "* user)\n");
             else
-                source.write("int decode" + support.prefix + name + support.packetStructureSuffix + "(const void* pkt)\n");
+                source.write(INT_DECODE + extendedName() + "(const void* pkt)\n");
             source.write("{\n");
             source.write("    int numBytes;\n");
             source.write("    int byteindex = 0;\n");
@@ -565,7 +573,7 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write(" * \\param pkt points to the packet being decoded by this function\n");
             source.write(" * \\return 0 is returned if the packet ID is wrong, else 1\n");
             source.write(" */\n");
-            source.write("int decode" + support.prefix + name + support.packetStructureSuffix + "(const void* pkt)\n");
+            source.write(INT_DECODE + extendedName() + "(const void* pkt)\n");
             source.write("{\n");
             if(ids.count() <= 1)
             {
@@ -815,7 +823,7 @@ void ProtocolPacket::createPacketFunctions(void)
  */
 QString ProtocolPacket::getPacketEncodeSignature(void) const
 {
-    QString output = "void encode" + support.prefix + name + support.packetParameterSuffix + "(void* pkt";
+    QString output = VOID_ENCODE + support.prefix + name + support.packetParameterSuffix + "(void* pkt";
 
     output += getDataEncodeParameterList();
 
@@ -833,7 +841,7 @@ QString ProtocolPacket::getPacketEncodeSignature(void) const
  */
 QString ProtocolPacket::getPacketDecodeSignature(void) const
 {
-    QString output = "int decode" + support.prefix + name + support.packetParameterSuffix + "(const void* pkt";
+    QString output = INT_DECODE + support.prefix + name + support.packetParameterSuffix + "(const void* pkt";
 
     output += getDataDecodeParameterList() + ")";
 

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -19,6 +19,8 @@
 const QString VOID_ENCODE = "void encode";
 const QString INT_DECODE = "int decode";
 
+const QString TAB_IN = "    ";
+
 /*!
  * Construct the object that parses packet descriptions
  * \param parse points to the global protocol parser that owns everything
@@ -415,23 +417,23 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write("{\n");
         }
 
-        source.write("    uint8_t* data = get" + support.protoName + "PacketData(pkt);\n");
-        source.write("    int byteindex = 0;\n");
+        source.write(TAB_IN + "uint8_t* data = get" + support.protoName + "PacketData(pkt);\n");
+        source.write(TAB_IN + "int byteindex = 0;\n");
 
         if(bitfields)
-            source.write("    int bitcount = 0;\n");
+            source.write(TAB_IN + "int bitcount = 0;\n");
 
         if(numbitfieldgroupbytes > 0)
         {
-            source.write("    int bitfieldindex = 0;\n");
-            source.write("    uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
+            source.write(TAB_IN + "int bitfieldindex = 0;\n");
+            source.write(TAB_IN + "uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
         }
 
         if(needsEncodeIterator)
-            source.write("    int i = 0;\n");
+            source.write(TAB_IN + "int i = 0;\n");
 
         if(needs2ndEncodeIterator)
-            source.write("    int j = 0;\n");
+            source.write(TAB_IN + "int j = 0;\n");
 
         int bitcount = 0;
         for(int i = 0; i < encodables.length(); i++)
@@ -441,12 +443,12 @@ void ProtocolPacket::createStructurePacketFunctions(void)
         }
 
         source.makeLineSeparator();
-        source.write("    // complete the process of creating the packet\n");
+        source.write(TAB_IN + "// complete the process of creating the packet\n");
 
         if(ids.count() <= 1)
-            source.write("    finish" + support.protoName + "Packet(pkt, byteindex, get" + support.prefix + name + support.packetParameterSuffix + "ID());\n");
+            source.write(TAB_IN + "finish" + support.protoName + "Packet(pkt, byteindex, get" + support.prefix + name + support.packetParameterSuffix + "ID());\n");
         else
-            source.write("    finish" + support.protoName + "Packet(pkt, byteindex, id);\n");
+            source.write(TAB_IN + "finish" + support.protoName + "Packet(pkt, byteindex, id);\n");
 
         source.write("}\n");
     }
@@ -472,52 +474,52 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             else
                 source.write(INT_DECODE + extendedName() + "(const void* pkt)\n");
             source.write("{\n");
-            source.write("    int numBytes;\n");
-            source.write("    int byteindex = 0;\n");
-            source.write("    const uint8_t* data;\n");
+            source.write(TAB_IN + "int numBytes;\n");
+            source.write(TAB_IN + "int byteindex = 0;\n");
+            source.write(TAB_IN + "const uint8_t* data;\n");
             if(bitfields)
-                source.write("    int bitcount = 0;\n");
+                source.write(TAB_IN + "int bitcount = 0;\n");
 
             if(numbitfieldgroupbytes > 0)
             {
-                source.write("    int bitfieldindex = 0;\n");
-                source.write("    uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
+                source.write(TAB_IN + "int bitfieldindex = 0;\n");
+                source.write(TAB_IN + "uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
             }
 
             if(needsDecodeIterator)
-                source.write("    int i = 0;\n");
+                source.write(TAB_IN + "int i = 0;\n");
             if(needs2ndDecodeIterator)
-                source.write("    int j = 0;\n");
+                source.write(TAB_IN + "int j = 0;\n");
             source.write("\n");
 
             if(ids.count() <= 1)
             {
-                source.write("    // Verify the packet identifier\n");
-                source.write("    if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
+                source.write(TAB_IN + "// Verify the packet identifier\n");
+                source.write(TAB_IN + "if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
             }
             else
             {
-                source.write("    // Verify the packet identifier, multiple options exist\n");
-                source.write("    uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
-                source.write("    if( packetid != " + ids.at(0));
+                source.write(TAB_IN + "// Verify the packet identifier, multiple options exist\n");
+                source.write(TAB_IN + "uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
+                source.write(TAB_IN + "if( packetid != " + ids.at(0));
                 for(int i = 1; i < ids.count(); i++)
                     source.write(" &&\n        packetid != " + ids.at(i));
                 source.write(" )\n");
             }
 
-            source.write("        return 0;\n");
+            source.write(TAB_IN + TAB_IN + "return 0;\n");
             source.write("\n");
-            source.write("    // Verify the packet size\n");
-            source.write("    numBytes = get" + support.protoName + "PacketSize(pkt);\n");
-            source.write("    if(numBytes < get" + support.prefix + name + "MinDataLength())\n");
-            source.write("        return 0;\n");
+            source.write(TAB_IN + "// Verify the packet size\n");
+            source.write(TAB_IN + "numBytes = get" + support.protoName + "PacketSize(pkt);\n");
+            source.write(TAB_IN + "if(numBytes < get" + support.prefix + name + "MinDataLength())\n");
+            source.write(TAB_IN + "    return 0;\n");
             source.write("\n");
-            source.write("    // The raw data from the packet\n");
-            source.write("    data = get" + support.protoName + "PacketDataConst(pkt);\n");
+            source.write(TAB_IN + "// The raw data from the packet\n");
+            source.write(TAB_IN + "data = get" + support.protoName + "PacketDataConst(pkt);\n");
             source.makeLineSeparator();
             if(defaults)
             {
-                source.write("    // this packet has default fields, make sure they are set\n");
+                source.write(TAB_IN + "// this packet has default fields, make sure they are set\n");
 
                 for(int i = 0; i < encodables.size(); i++)
                     source.write(encodables[i]->getSetToDefaultsString(true));
@@ -546,9 +548,9 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             if((encodedLength.minEncodedLength != encodedLength.nonDefaultEncodedLength) && (i > 0))
             {
                 source.makeLineSeparator();
-                source.write("    // Used variable length arrays or dependent fields, check actual length\n");
-                source.write("    if(numBytes < byteindex)\n");
-                source.write("        return 0;\n");
+                source.write(TAB_IN + "// Used variable length arrays or dependent fields, check actual length\n");
+                source.write(TAB_IN + "if(numBytes < byteindex)\n");
+                source.write(TAB_IN + "    return 0;\n");
             }
 
             // Now finish the fields (if any defaults)
@@ -559,7 +561,7 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             }
 
             source.makeLineSeparator();
-            source.write("    return 1;\n");
+            source.write(TAB_IN + "return 1;\n");
             source.write("}\n");
 
         }// if fields to decode
@@ -577,21 +579,21 @@ void ProtocolPacket::createStructurePacketFunctions(void)
             source.write("{\n");
             if(ids.count() <= 1)
             {
-                source.write("    // Verify the packet identifier\n");
-                source.write("    if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
+                source.write(TAB_IN + "// Verify the packet identifier\n");
+                source.write(TAB_IN + "if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
             }
             else
             {
-                source.write("    // Verify the packet identifier, multiple options exist\n");
-                source.write("    uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
-                source.write("    if( packetid != " + ids.at(0));
+                source.write(TAB_IN + "// Verify the packet identifier, multiple options exist\n");
+                source.write(TAB_IN + "uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
+                source.write(TAB_IN + "if( packetid != " + ids.at(0));
                 for(int i = 1; i < ids.count(); i++)
                     source.write(" &&\n        packetid != " + ids.at(i));
                 source.write(" )\n");
             }
-            source.write("        return 0;\n");
-            source.write("    else\n");
-            source.write("        return 1;\n");
+            source.write(TAB_IN + TAB_IN + "return 0;\n");
+            source.write(TAB_IN + "else\n");
+            source.write(TAB_IN + "    return 1;\n");
             source.write("}\n");
 
         }// else if no fields to decode
@@ -645,23 +647,23 @@ void ProtocolPacket::createPacketFunctions(void)
 
         if(!encodedLength.isZeroLength())
         {
-            source.write("    uint8_t* data = get"+ support.protoName + "PacketData(pkt);\n");
-            source.write("    int byteindex = 0;\n");
+            source.write(TAB_IN + "uint8_t* data = get"+ support.protoName + "PacketData(pkt);\n");
+            source.write(TAB_IN + "int byteindex = 0;\n");
 
             if(bitfields)
-                source.write("    int bitcount = 0;\n");
+                source.write(TAB_IN + "int bitcount = 0;\n");
 
             if(numbitfieldgroupbytes > 0)
             {
-                source.write("    int bitfieldindex = 0;\n");
-                source.write("    uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
+                source.write(TAB_IN + "int bitfieldindex = 0;\n");
+                source.write(TAB_IN + "uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
             }
 
             if(needsEncodeIterator)
-                source.write("    int i = 0;\n");
+                source.write(TAB_IN + "int i = 0;\n");
 
             if(needs2ndEncodeIterator)
-                source.write("    int j = 0;\n");
+                source.write(TAB_IN + "int j = 0;\n");
 
             // Keep our own track of the bitcount so we know what to do when we close the bitfield
             for(i = 0; i < encodables.length(); i++)
@@ -671,19 +673,19 @@ void ProtocolPacket::createPacketFunctions(void)
             }
 
             source.makeLineSeparator();
-            source.write("    // complete the process of creating the packet\n");
+            source.write(TAB_IN + "// complete the process of creating the packet\n");
             if(ids.count() <= 1)
-                source.write("    finish" + support.protoName + "Packet(pkt, byteindex, get" + support.prefix + name + support.packetParameterSuffix + "ID());\n");
+                source.write(TAB_IN + "finish" + support.protoName + "Packet(pkt, byteindex, get" + support.prefix + name + support.packetParameterSuffix + "ID());\n");
             else
-                source.write("    finish" + support.protoName + "Packet(pkt, byteindex, id);\n");
+                source.write(TAB_IN + "finish" + support.protoName + "Packet(pkt, byteindex, id);\n");
         }
         else
         {
-            source.write("    // Zero length packet, no data encoded\n");
+            source.write(TAB_IN + "// Zero length packet, no data encoded\n");
             if(ids.count() <= 1)
-                source.write("    finish" + support.protoName + "Packet(pkt, 0, get" + support.prefix + name + support.packetParameterSuffix + "ID());\n");
+                source.write(TAB_IN + "finish" + support.protoName + "Packet(pkt, 0, get" + support.prefix + name + support.packetParameterSuffix + "ID());\n");
             else
-                source.write("    finish" + support.protoName + "Packet(pkt, 0, id);\n");
+                source.write(TAB_IN + "finish" + support.protoName + "Packet(pkt, 0, id);\n");
         }
 
         source.write("}\n");
@@ -708,46 +710,46 @@ void ProtocolPacket::createPacketFunctions(void)
         if(!encodedLength.isZeroLength())
         {
             if(bitfields)
-                source.write("    int bitcount = 0;\n");
+                source.write(TAB_IN + "int bitcount = 0;\n");
 
             if(numbitfieldgroupbytes > 0)
             {
-                source.write("    int bitfieldindex = 0;\n");
-                source.write("    uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
+                source.write(TAB_IN + "int bitfieldindex = 0;\n");
+                source.write(TAB_IN + "uint8_t bitfieldbytes[" + QString::number(numbitfieldgroupbytes) + "];\n");
             }
 
             if(needsDecodeIterator)
-                source.write("    int i = 0;\n");
+                source.write(TAB_IN + "int i = 0;\n");
             if(needs2ndDecodeIterator)
-                source.write("    int j = 0;\n");
-            source.write("    int byteindex = 0;\n");
-            source.write("    const uint8_t* data = get" + support.protoName + "PacketDataConst(pkt);\n");
-            source.write("    int numBytes = get" + support.protoName + "PacketSize(pkt);\n");
+                source.write(TAB_IN + "int j = 0;\n");
+            source.write(TAB_IN + "int byteindex = 0;\n");
+            source.write(TAB_IN + "const uint8_t* data = get" + support.protoName + "PacketDataConst(pkt);\n");
+            source.write(TAB_IN + "int numBytes = get" + support.protoName + "PacketSize(pkt);\n");
             source.write("\n");
 
             if(ids.count() <= 1)
             {
-                source.write("    // Verify the packet identifier\n");
-                source.write("    if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
+                source.write(TAB_IN + "// Verify the packet identifier\n");
+                source.write(TAB_IN + "if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
             }
             else
             {
-                source.write("    // Verify the packet identifier, multiple options exist\n");
-                source.write("    uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
-                source.write("    if( packetid != " + ids.at(0));
+                source.write(TAB_IN + "// Verify the packet identifier, multiple options exist\n");
+                source.write(TAB_IN + "uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
+                source.write(TAB_IN + "if( packetid != " + ids.at(0));
                 for(int i = 1; i < ids.count(); i++)
                     source.write(" &&\n        packetid != " + ids.at(i));
                 source.write(" )\n");
             }
-            source.write("        return 0;\n");
+            source.write(TAB_IN + TAB_IN + "return 0;\n");
 
             source.write("\n");
-            source.write("    if(numBytes < get" + support.prefix + name + "MinDataLength())\n");
-            source.write("        return 0;\n");
+            source.write(TAB_IN + "if(numBytes < get" + support.prefix + name + "MinDataLength())\n");
+            source.write(TAB_IN + TAB_IN + "return 0;\n");
             if(defaults)
             {
                 source.write("\n");
-                source.write("    // this packet has default fields, make sure they are set\n");
+                source.write(TAB_IN + "// this packet has default fields, make sure they are set\n");
 
                 for(int i = 0; i < encodables.size(); i++)
                     source.write(encodables[i]->getSetToDefaultsString(false));
@@ -773,9 +775,9 @@ void ProtocolPacket::createPacketFunctions(void)
             if((encodedLength.minEncodedLength != encodedLength.nonDefaultEncodedLength) && (i > 0))
             {
                 source.makeLineSeparator();
-                source.write("    // Used variable length arrays or dependent fields, check actual length\n");
-                source.write("    if(numBytes < byteindex)\n");
-                source.write("        return 0;\n");
+                source.write(TAB_IN + "// Used variable length arrays or dependent fields, check actual length\n");
+                source.write(TAB_IN + "if(numBytes < byteindex)\n");
+                source.write(TAB_IN + TAB_IN + "return 0;\n");
             }
 
             // Now finish the fields (if any defaults)
@@ -786,28 +788,28 @@ void ProtocolPacket::createPacketFunctions(void)
             }
 
             source.makeLineSeparator();
-            source.write("    return 1;\n");
+            source.write(TAB_IN + "return 1;\n");
 
         }// if some fields to decode
         else
         {
             if(ids.count() <= 1)
             {
-                source.write("    // Verify the packet identifier\n");
-                source.write("    if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
+                source.write(TAB_IN + "// Verify the packet identifier\n");
+                source.write(TAB_IN + "if(get"+ support.protoName + "PacketID(pkt) != get" + support.prefix + name + support.packetParameterSuffix + "ID())\n");
             }
             else
             {
-                source.write("    // Verify the packet identifier, multiple options exist\n");
-                source.write("    uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
-                source.write("    if( packetid != " + ids.at(0));
+                source.write(TAB_IN + "// Verify the packet identifier, multiple options exist\n");
+                source.write(TAB_IN + "uint32_t packetid = get"+ support.protoName + "PacketID(pkt);\n");
+                source.write(TAB_IN + "if( packetid != " + ids.at(0));
                 for(int i = 1; i < ids.count(); i++)
                     source.write(" &&\n        packetid != " + ids.at(i));
                 source.write(" )\n");
             }
-            source.write("        return 0;\n");
-            source.write("    else\n");
-            source.write("        return 1;\n");
+            source.write(TAB_IN + TAB_IN + "return 0;\n");
+            source.write(TAB_IN + "else\n");
+            source.write(TAB_IN + TAB_IN + "return 1;\n");
 
         }// If no fields to decode
 

--- a/protocolpacket.h
+++ b/protocolpacket.h
@@ -33,6 +33,9 @@ public:
     //! Get all the ID strings of this packet
     void appendIds(QStringList& list) const {list.append(ids);}
 
+    //! Return the extended packet name
+    QString extendedName() const { return support.prefix + this->name + support.packetStructureSuffix; }
+
 protected:
 
     //! Create the structure definition code

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -505,19 +505,19 @@ void ProtocolParser::createProtocolFiles(const QDomElement& docElem)
     header.write("// They are not auto-generated functions, but must be hand-written\n");
     header.write("\n");
     header.write("//! \\return the packet data pointer from the packet\n");
-    header.write("uint8_t* get" + name + "PacketData(void* pkt);\n");
+    header.write("uint8_t* get" + name + "PacketData(" + support.pointerType + " pkt);\n");
     header.write("\n");
     header.write("//! \\return the packet data pointer from the packet, const\n");
-    header.write("const uint8_t* get" + name + "PacketDataConst(const void* pkt);\n");
+    header.write("const uint8_t* get" + name + "PacketDataConst(const " + support.pointerType + " pkt);\n");
     header.write("\n");
     header.write("//! Complete a packet after the data have been encoded\n");
-    header.write("void finish" + name + "Packet(void* pkt, int size, uint32_t packetID);\n");
+    header.write("void finish" + name + "Packet(" + support.pointerType + " pkt, int size, uint32_t packetID);\n");
     header.write("\n");
     header.write("//! \\return the size of a packet from the packet header\n");
-    header.write("int get" + name + "PacketSize(const void* pkt);\n");
+    header.write("int get" + name + "PacketSize(const " + support.pointerType + " pkt);\n");
     header.write("\n");
     header.write("//! \\return the ID of a packet from the packet header\n");
-    header.write("uint32_t get" + name + "PacketID(const void* pkt);\n");
+    header.write("uint32_t get" + name + "PacketID(const " + support.pointerType + " pkt);\n");
     header.write("\n");
 
     header.flush();

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -4,6 +4,7 @@
 #include <QStringList>
 #include <iostream>
 
+const QString VOID_ENCODE = "void encode";
 
 /*!
  * Construct a protocol structure
@@ -616,6 +617,21 @@ QString ProtocolStructure::alignStructureData(const QString& structure) const
 
 }// ProtocolStructure::alignStructureData
 
+QString ProtocolStructure::getFunctionEncodePrototype() const
+{
+    QString output;
+
+    if(getNumberOfEncodeParameters() > 0)
+    {
+        output = VOID_ENCODE + typeName + "(uint8_t* data, int* bytecount, const " + typeName + "* user)";
+    }
+    else
+    {
+        output = VOID_ENCODE + typeName + "(uint8_t* data, int* bytecount)";
+    }
+
+    return output;
+}
 
 /*!
  * Return the string that gives the prototype of the functions used to encode
@@ -643,10 +659,8 @@ QString ProtocolStructure::getPrototypeEncodeString(bool isBigEndian, bool inclu
 
     // My encoding and decoding prototypes in the header file
     output += "//! Encode a " + typeName + " structure into a byte array\n";
-    if(getNumberOfEncodeParameters() > 0)
-        output += "void encode" + typeName + "(uint8_t* data, int* bytecount, const " + typeName + "* user);\n";
-    else
-        output += "void encode" + typeName + "(uint8_t* data, int* bytecount);\n";
+
+    output += getFunctionEncodePrototype() + ";\n";
 
     return output;
 
@@ -689,10 +703,9 @@ QString ProtocolStructure::getFunctionEncodeString(bool isBigEndian, bool includ
     if(numEncodes > 0)
         output += " * \\param user is the data to encode in the byte array\n";
     output += " */\n";
-    if(numEncodes > 0)
-        output += "void encode" + typeName + "(uint8_t* data, int* bytecount, const " + typeName + "* user)\n";
-    else
-        output += "void encode" + typeName + "(uint8_t* data, int* bytecount)\n";
+
+    output += getFunctionEncodePrototype() + "\n";
+
     output += "{\n";
 
     output += "    int byteindex = *bytecount;\n";

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -742,6 +742,19 @@ QString ProtocolStructure::getFunctionEncodeString(bool isBigEndian, bool includ
 }// ProtocolStructure::getFunctionEncodeString
 
 
+QString ProtocolStructure::getFunctionDecodePrototype() const
+{
+    QString output;
+
+    if(getNumberOfDecodeParameters() > 0)
+        output = "int decode" + typeName + "(const uint8_t* data, int* bytecount, " + typeName + "* user)";
+    else
+        output = "int decode" + typeName + "(const uint8_t* data, int* bytecount)";
+
+    return output;
+}
+
+
 /*!
  * Return the string that gives the prototype of the functions used to decode
  * the structure. The encoding is to a simple byte array.
@@ -768,10 +781,7 @@ QString ProtocolStructure::getPrototypeDecodeString(bool isBigEndian, bool inclu
 
     output += "//! Decode a " + typeName + " structure from a byte array\n";
 
-    if(getNumberOfDecodeParameters() > 0)
-        output += "int decode" + typeName + "(const uint8_t* data, int* bytecount, " + typeName + "* user);\n";
-    else
-        output += "int decode" + typeName + "(const uint8_t* data, int* bytecount);\n";
+    output += getFunctionDecodePrototype() + ";\n";
 
     return output;
 
@@ -814,10 +824,8 @@ QString ProtocolStructure::getFunctionDecodeString(bool isBigEndian, bool includ
         output += " * \\param user is the data to decode from the byte array\n";
     output += " * \\return 1 if the data are decoded, else 0. If 0 is returned bytecount will not be updated.\n";
     output += " */\n";
-    if(numDecodes > 0)
-        output += "int decode" + typeName + "(const uint8_t* data, int* bytecount, " + typeName + "* user)\n";
-    else
-        output += "int decode" + typeName + "(const uint8_t* data, int* bytecount)\n";
+
+    output += getFunctionDecodePrototype() + "\n";
 
     output += "{\n";
 

--- a/protocolstructure.h
+++ b/protocolstructure.h
@@ -85,8 +85,11 @@ public:
     //! Return the string that gives the function used to decode this encodable, may be empty
     virtual QString getFunctionDecodeString(bool isBigEndian, bool includeChildren = true) const;
 
-    //! Return the string that is used to prototype this encodable
+    //! Return the string that is used to prototype the encode routine for this encodable
     virtual QString getFunctionEncodePrototype() const;
+
+    //! Return the string that is used to prototype the decode routine for this encodable
+    virtual QString getFunctionDecodePrototype() const;
 
     //! Return the string that is used to encode this encodable
     virtual QString getEncodeString(bool isBigEndian, int* bitcount, bool isStructureMember) const;

--- a/protocolstructure.h
+++ b/protocolstructure.h
@@ -85,6 +85,9 @@ public:
     //! Return the string that gives the function used to decode this encodable, may be empty
     virtual QString getFunctionDecodeString(bool isBigEndian, bool includeChildren = true) const;
 
+    //! Return the string that is used to prototype this encodable
+    virtual QString getFunctionEncodePrototype() const;
+
     //! Return the string that is used to encode this encodable
     virtual QString getEncodeString(bool isBigEndian, int* bitcount, bool isStructureMember) const;
 

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -22,7 +22,19 @@ QStringList ProtocolSupport::getAttriblist(void) const
 {
     QStringList attribs;
 
-    attribs << "maxSize" << "supportInt64" << "supportFloat64" << "supportSpecialFloat" << "supportBitfield" << "supportLongBitfield" << "bitfieldTest" << "file" << "prefix" << "packetStructureSuffix" << "packetParameterSuffix" << "endian";
+    attribs << "maxSize"
+            << "supportInt64"
+            << "supportFloat64"
+            << "supportSpecialFloat"
+            << "supportBitfield"
+            << "supportLongBitfield"
+            << "bitfieldTest"
+            << "file"
+            << "prefix"
+            << "packetStructureSuffix"
+            << "packetParameterSuffix"
+            << "endian"
+            << "pointer";
 
     return attribs;
 }
@@ -64,8 +76,13 @@ void ProtocolSupport::parse(const QDomNamedNodeMap& map)
     // Prefix is not required
     prefix = ProtocolParser::getAttribute("prefix", map);
 
-    // Packet pointer type
-    pointerType = ProtocolParser::getAttribute("pointer", map);
+    // Packet pointer type (default is 'void')
+    pointerType = ProtocolParser::getAttribute("pointer", map, "void");
+
+    if(!pointerType.endsWith("*"))
+    {
+        pointerType += "*";
+    }
 
     // Packet name post fixes
     packetStructureSuffix = ProtocolParser::getAttribute("packetStructureSuffix", map, packetStructureSuffix);

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -64,6 +64,9 @@ void ProtocolSupport::parse(const QDomNamedNodeMap& map)
     // Prefix is not required
     prefix = ProtocolParser::getAttribute("prefix", map);
 
+    // Packet pointer type
+    pointerType = ProtocolParser::getAttribute("pointer", map);
+
     // Packet name post fixes
     packetStructureSuffix = ProtocolParser::getAttribute("packetStructureSuffix", map, packetStructureSuffix);
     packetParameterSuffix = ProtocolParser::getAttribute("packetParameterSuffix", map, packetParameterSuffix);

--- a/protocolsupport.h
+++ b/protocolsupport.h
@@ -30,6 +30,7 @@ public:
     QString packetParameterSuffix;  //!< Name to use at end of encode/decode Packet parameter functions
     QString protoName;              //!< Name of the protocol
     QString prefix;                 //!< Prefix name
+    QString pointerType;            //!< Packet pointer type - default is "void*"
 };
 
 #endif // PROTOCOLSUPPORT_H


### PR DESCRIPTION
This PR adds the ability to specify the PacketType, rather than refer to the packet using a generic void* pointer.

The benefits of this are twofold:

a) There is no casting protection offered by a void* pointer, and the following code will compile (but not *work*):

```
void* pktPtr = (void*) &pkt;

decodePacket(&pktPtr);
decodePacket(pktPtr);
````

b) The glue-functions can be written without void casting, e.g.

```
//! \return the packet data pointer from the packet
uint8_t* getTestProtocolPacketData(CustomPacket* pkt);
```