### PR TITLE
enum handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Enum tag attributes:
 
 - `hidden` : is used to specify that this particular enumeration will *not* appear in the generated documentation markdown. NOTE: This enumeration will still appear in the generated code.
 
-- `lookup` : is used to specify that this enumeration allows lookup of label text based on enum values. If enabled, the label for a particular enum value can be returned as a string.f
+- `lookup` : is used to specify that this enumeration allows lookup of label text based on enum values. If enabled, the label for a particular enum value can be returned as a string.
 
 ###Enum : Value subtag attributes:
 

--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -6,6 +6,8 @@
 #include <math.h>
 #include <iostream>
 
+const QString TAB = "    ";
+
 EnumElement::EnumElement(ProtocolParser *parse, EnumCreator *creator, QString Parent, ProtocolSupport supported) :
     ProtocolDocumentation(parse, Parent, supported),
     parentEnum(creator)
@@ -22,6 +24,21 @@ EnumCreator::EnumCreator(ProtocolParser* parse, QString Parent, ProtocolSupport 
 {
 }
 
+void EnumElement::checkAgainstKeywords()
+{
+    if (keywords.contains(getName()))
+    {
+        emitWarning("enum value name matches C keyword, changed to name_");
+        m_name += "_";
+    }
+
+    if (keywords.contains(getValue()))
+    {
+        emitWarning("enum value matches C keyword, changed to value_");
+        m_value += "_";
+    }
+}
+
 void EnumElement::parse()
 {
     auto map = e.attributes();
@@ -35,13 +52,48 @@ void EnumElement::parse()
                           << "ignorePrefix"
                           << "ignoreLookup");
 
-    Name = ProtocolParser::getAttribute("name", map);
-    LookupName = ProtocolParser::getAttribute("lookupName", map);
-    Value = ProtocolParser::getAttribute("value", map);
-    Comment = ProtocolParser::getAttribute("comment", map);
-    IsHidden = ProtocolParser::isFieldSet("hidden", map);
-    IgnoresPrefix = ProtocolParser::isFieldSet("ignorePrefix", map);
-    IgnoresLookup = ProtocolParser::isFieldSet("ignoreLookup", map);
+    m_name = ProtocolParser::getAttribute("name", map);
+    m_lookupName = ProtocolParser::getAttribute("lookupName", map);
+    m_value = ProtocolParser::getAttribute("value", map);
+    m_comment = ProtocolParser::getAttribute("comment", map);
+    m_isHidden = ProtocolParser::isFieldSet("hidden", map);
+    m_ignoresPrefix = ProtocolParser::isFieldSet("ignorePrefix", map);
+    m_ignoresLookup = ProtocolParser::isFieldSet("ignoreLookup", map);
+
+    checkAgainstKeywords();
+}
+
+QString EnumElement::getName() const
+{
+    QString name = m_ignoresPrefix ? QString("") : parentEnum->getPrefix();
+
+    name += m_name;
+
+    return name;
+}
+
+QString EnumElement::getLookupName() const
+{
+    if (m_lookupName.isEmpty())
+    {
+        return getName();
+    }
+    else
+    {
+        return m_lookupName;
+    }
+}
+
+QString EnumElement::getDeclaration() const
+{
+    QString decl = getName();
+
+    if (!m_value.isEmpty())
+    {
+        decl += " = " + m_value;
+    }
+
+    return decl;
 }
 
 EnumCreator::~EnumCreator(void)
@@ -68,12 +120,7 @@ void EnumCreator::clear(void)
     comment.clear();
     description.clear();
     output.clear();
-    nameList.clear();
     prefix.clear();
-    commentList.clear();
-    valueList.clear();
-    numberList.clear();
-    hiddenList.clear();
 
     // Delete all the objects in the list
     for(int i = 0; i < documentList.count(); i++)
@@ -156,55 +203,22 @@ void EnumCreator::parse(void)
         output += " */\n";
     }
 
-    QStringList declarationList;
+    elements.clear();
 
     int maxLength = 0;
-    for(int i = 0; i < list.size(); i++)
+
+    for (int i=0; i<list.size(); i++)
     {
-        QDomElement field = list.at(i).toElement();
+        EnumElement elem(parser, this, parent, support);
 
-        if(field.isNull())
-            continue;
+        elem.setElement(list.at(i).toElement());
 
-        QDomNamedNodeMap map = field.attributes();
+        elem.parse();
 
-        // We use name as part of our debug outputs, so its good to have it first.
-        QString valueName = ProtocolParser::getAttribute("name", map);
-
-        // Tell the user of any problems in the attributes
-        testAndWarnAttributes(map, QStringList() <<  "name" << "value" << "comment" << "hidden" << "ignorePrefix", valueName);
-
-        // Now get the attributes
-        QString value = ProtocolParser::getAttribute("value", map);
-        QString comment = ProtocolParser::reflowComment(ProtocolParser::getAttribute("comment", map));
-        bool hiddenvalue = ProtocolParser::isFieldSet("hidden", map);
-        bool ignorePrefix = ProtocolParser::isFieldSet("ignorePrefix", map);
-
-        // Add the enum prefix if applicable
-        if ( !prefix.isEmpty() && !ignorePrefix )
-            valueName = prefix + valueName;
-
-        // Add it to our list
-        nameList.append(valueName);
-
-        // The declared value, which may be empty
-        valueList.append(value);
-
-        // And don't forget the comment
-        commentList.append(comment);
-
-        // Specific enum values can be hidden
-        hiddenList.append(hiddenvalue);
-
-        // Form the declaration string
-        QString declaration = "    " + valueName;
-        if(!value.isEmpty())
-            declaration += " = " + value;
-
-        declarationList.append(declaration);
+        elements.append(elem);
 
         // Track the longest declaration
-        int length = declaration.length();
+        int length = elem.getDeclaration().length();
         if(length > maxLength)
             maxLength = length;
 
@@ -226,30 +240,34 @@ void EnumCreator::parse(void)
     output += "typedef enum\n";
     output += "{\n";
 
-    for(int i = 0; i < declarationList.size(); i++)
+    for(int i = 0; i < elements.size(); i++)
     {
+        auto element = elements.at(i);
+
+        auto declaration = TAB + element.getDeclaration();
+
         // Output the enumerator name and separator
-        output += declarationList.at(i);
+        output += declaration;
 
         // Output a comma separator or space for the last item
-        if(i < (declarationList.size() - 1))
+        if(i < (elements.size() - 1))
             output += ",";
         else
             output += " ";
 
         // Pad to maxLength
-        for(int j = declarationList.at(i).length(); j < maxLength; j++)
+        for(int j = declaration.length(); j < maxLength; j++)
             output += " ";
 
         // Output the comment
-        if(commentList.at(i).isEmpty())
+        if(element.getComment().isEmpty())
             output += "\n";
         else
-            output += "//!< " + commentList.at(i) + "\n";
+            output += "//!< " + element.getComment() + "\n";
 
     }// for all enumerators
 
-    output += "}";
+    output += "} ";
     output += name;
     output += ";\n";
 
@@ -273,18 +291,23 @@ void EnumCreator::parse(void)
         sourceOutput += func + "\n";
         sourceOutput += "{\n";
 
-        sourceOutput += "    switch (value)\n";
-        sourceOutput += "    {\n";
-        sourceOutput += "    default:\n";
-        sourceOutput += "        return \"\";\n";
+        sourceOutput += TAB + "switch (value)\n";
+        sourceOutput += TAB + "\n";
+        sourceOutput += TAB + "default:\n";
+        sourceOutput += TAB + TAB + "return \"\";\n";
 
-        for (int i=0; i < nameList.size(); i++ )
+        for (int i=0; i<elements.size(); i++)
         {
-            sourceOutput += "    case " + nameList.at(i) + ":\n";
-            sourceOutput += "        return \"" + nameList.at(i) + "\";\n";
+            auto element = elements.at(i);
+
+            if (element.ignoresLookup())
+                continue;
+
+            sourceOutput += TAB + "case " + element.getName() + ":\n";
+            sourceOutput += TAB + TAB + "return \"" + element.getLookupName() + "\";\n";
         }
 
-        sourceOutput += "    }\n";
+        sourceOutput += TAB + "}\n";
         sourceOutput += "}\n";
     }
 
@@ -298,22 +321,6 @@ void EnumCreator::checkAgainstKeywords(void)
     {
         emitWarning("name matches C keyword, changed to _name");
         name = "_" + name;
-    }
-
-    for(int i = 0; i < nameList.size(); i++)
-    {
-        if(keywords.contains(nameList.at(i)))
-        {
-            emitWarning("enum value name matches C keyword, changed to _name");
-            nameList[i] = "_" + nameList.at(i);
-        }
-
-        if(keywords.contains(valueList.at(i)))
-        {
-            emitWarning("enum value matches C keyword, changed to _value");
-            valueList[i] = "_" + valueList.at(i);
-        }
-
     }
 
 }// EnumCreator::checkAgainstKeywords
@@ -330,10 +337,13 @@ void EnumCreator::computeNumberList(void)
     int maxValue = 1;
     int value = -1;
     QString baseString;
-    for(int i = 0; i < valueList.length(); i++)
+
+    for (int i=0; i<elements.size(); i++)
     {
+        auto& element = elements[i];
+
         // The string from the XML, which may be empty
-        QString stringValue = valueList.at(i);
+        QString stringValue = element.getValue();
 
         // Clear any whitespace from it just to be sure
         stringValue = stringValue.trimmed();
@@ -346,12 +356,13 @@ void EnumCreator::computeNumberList(void)
             // Is this incremented value absolute, or referenced to
             // some other string we could not resolve?
             if(baseString.isEmpty())
+            {
                 stringValue.setNum(value);
+            }
             else
+            {
                 stringValue = baseString + " + " + QString().setNum(value);
-
-            // Append to the number list
-            numberList.append(stringValue);
+            }
 
         }// if the xml was empty
         else
@@ -382,19 +393,17 @@ void EnumCreator::computeNumberList(void)
                 baseString = stringValue;
                 value = 0;
 
-                // No useful information is available
-                numberList.append(QString());
+                stringValue = QString();
             }
             else
             {
                 baseString.clear();
                 stringValue.setNum(value);
-
-                // Append to the number list
-                numberList.append(stringValue);
             }
 
         }// if we got a string from the xml
+
+        element.setNumber(stringValue);
 
         // keep track of maximum value
         if(value > maxValue)
@@ -424,7 +433,7 @@ QString EnumCreator::getTopLevelMarkdown(bool global, const QStringList& packeti
 {
     QString output;
 
-    if(nameList.length() > 0)
+    if(elements.size() > 0)
     {
         QStringList codeNameList;
 
@@ -432,32 +441,40 @@ QString EnumCreator::getTopLevelMarkdown(bool global, const QStringList& packeti
         int firstColumnSpacing = QString("Name").length();
         int secondColumnSpacing = QString("Value").length();
         int thirdColumnSpacing = QString("Description").length();
-        for(int i = 0; i < nameList.length(); i++)
+
+        for(int i = 0; i < elements.size(); i++)
         {
+            auto element = elements.at(i);
+
             bool link = false;
 
             // Check to see if this enumeration is a packet identifier
             for(int j = 0; j < packetids.size(); j++)
             {
-                if(packetids.at(j) == nameList.at(i))
+                if(packetids.at(j) == element.getName())
                 {
                     link = true;
                     break;
                 }
             }
 
+            QString linkText;
+
             // Mark name as code, with or without a link to an anchor elsewhere
             if(link)
-                codeNameList.append("[`" + nameList.at(i) + "`](#" + nameList.at(i) + ")");
+            {
+                linkText = "[`" + element.getName() + "`](#" + element.getName() + ")";
+            }
             else
-                codeNameList.append("`" + nameList.at(i) + "`");
+            {
+                linkText = "`" + element.getName() + "`";
+            }
 
-            if(firstColumnSpacing < codeNameList.at(i).length())
-                firstColumnSpacing = codeNameList.at(i).length();
-            if(secondColumnSpacing < numberList.at(i).length())
-                secondColumnSpacing = numberList.at(i).length();
-            if(thirdColumnSpacing < commentList.at(i).length())
-                thirdColumnSpacing = commentList.at(i).length();
+            codeNameList.append(linkText);
+
+            firstColumnSpacing = qMax(firstColumnSpacing, linkText.length());
+            secondColumnSpacing = qMax(secondColumnSpacing, element.getNumber().length());
+            thirdColumnSpacing = qMax(thirdColumnSpacing, element.getComment().length());
         }
 
         // The outline paragraph
@@ -506,18 +523,19 @@ QString EnumCreator::getTopLevelMarkdown(bool global, const QStringList& packeti
         // Now write out the outputs
         for(int i = 0; i < codeNameList.length(); i++)
         {
+            auto element = elements.at(i);
+
             // Skip hidden values
-            if(hiddenList.at(i) == true)
+            if(element.isHidden())
                 continue;
 
             output += "| ";
-            output += spacedString(codeNameList.at(i), firstColumnSpacing);
+            output += spacedString(element.getName(), firstColumnSpacing);
             output += " | ";
-            output += spacedString(numberList.at(i), secondColumnSpacing);
+            output += spacedString(element.getNumber(), secondColumnSpacing);
             output += " | ";
-            output += spacedString(commentList.at(i), thirdColumnSpacing);
+            output += spacedString(element.getComment(), thirdColumnSpacing);
             output += " |\n";
-
         }
 
         output += "\n";
@@ -542,20 +560,19 @@ QString& EnumCreator::replaceEnumerationNameWithValue(QString& text) const
 
     for(int j = 0; j < tokens.size(); j++)
     {
+        QString token = tokens.at(j).trimmed();
+
         // Don't look to replace the mathematical operators
-        if(isMathOperator(tokens.at(j).at(0)))
+        if(isMathOperator(token.at(0)))
             continue;
 
-        for(int i = 0; i < nameList.length(); i++)
+        for (auto element : elements )
         {
-            // If we don't have a name or number there is no point
-            if(nameList.at(i).isEmpty() || numberList.at(i).isEmpty())
-                continue;
-
             // The entire token must match before we will replace it
-            if(tokens.at(j).compare(nameList.at(i)) == 0)
-                tokens[j] = numberList.at(i);
-
+            if(token.compare(element.getName().trimmed()) == 0)
+            {
+                tokens[j] = element.getName();
+            }
         }// for all names
 
     }// for all tokens
@@ -634,13 +651,9 @@ bool EnumCreator::isMathOperator(QChar op) const
  */
 bool EnumCreator::isEnumerationValue(const QString& text) const
 {
-    for(int i = 0; i < nameList.length(); i++)
+    for (auto element : elements )
     {
-        // If we don't have a name there is no point
-        if(nameList.at(i).isEmpty())
-            continue;
-
-        if(text.compare(nameList.at(i)) == 0)
+        if (text.trimmed().compare(element.getName().trimmed()) == 0 )
             return true;
     }
 

--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -6,6 +6,11 @@
 #include <math.h>
 #include <iostream>
 
+EnumElement::EnumElement(ProtocolParser *parse, EnumCreator *creator, QString Parent, ProtocolSupport supported) :
+    ProtocolDocumentation(parse, Parent, supported),
+    parentEnum(creator)
+{
+}
 
 //! Create an empty enumeration list
 EnumCreator::EnumCreator(ProtocolParser* parse, QString Parent, ProtocolSupport supported) :
@@ -17,6 +22,27 @@ EnumCreator::EnumCreator(ProtocolParser* parse, QString Parent, ProtocolSupport 
 {
 }
 
+void EnumElement::parse()
+{
+    auto map = e.attributes();
+
+    testAndWarnAttributes(map, QStringList()
+                          << "name"
+                          << "lookupName"
+                          << "value"
+                          << "comment"
+                          << "hidden"
+                          << "ignorePrefix"
+                          << "ignoreLookup");
+
+    Name = ProtocolParser::getAttribute("name", map);
+    LookupName = ProtocolParser::getAttribute("lookupName", map);
+    Value = ProtocolParser::getAttribute("value", map);
+    Comment = ProtocolParser::getAttribute("comment", map);
+    IsHidden = ProtocolParser::isFieldSet("hidden", map);
+    IgnoresPrefix = ProtocolParser::isFieldSet("ignorePrefix", map);
+    IgnoresLookup = ProtocolParser::isFieldSet("ignoreLookup", map);
+}
 
 EnumCreator::~EnumCreator(void)
 {
@@ -61,7 +87,6 @@ void EnumCreator::clear(void)
 
     // clear the list
     documentList.clear();
-
 }
 
 
@@ -107,8 +132,8 @@ void EnumCreator::parse(void)
     description = ProtocolParser::getAttribute("description", map);
     prefix = ProtocolParser::getAttribute("prefix", map);
     comment = ProtocolParser::reflowComment(ProtocolParser::getAttribute("comment", map));
-    hidden = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("hidden", map));
-    lookup = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("lookup", map));
+    hidden = ProtocolParser::isFieldSet("hidden", map);
+    lookup = ProtocolParser::isFieldSet("lookup", map);
 
     if(isglobal)
     {

--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -283,7 +283,7 @@ void EnumCreator::parse(void)
         output += "\n";
         output += "//! \\return the label of a '" + name + "' enum entry, based on its value\n";
 
-        QString func = "const char* " + name + "_Label(int value)";
+        QString func = "const char* " + name + "_EnumLabel(int value)";
 
         output += func + ";\n";
 
@@ -299,10 +299,11 @@ void EnumCreator::parse(void)
         sourceOutput += "{\n";
 
         sourceOutput += TAB + "switch (value)\n";
-        sourceOutput += TAB + "\n";
+        sourceOutput += TAB + "{\n";
         sourceOutput += TAB + "default:\n";
         sourceOutput += TAB + TAB + "return \"\";\n";
 
+        // Add the reverse-lookup text for each entry in the enumeration
         for (int i=0; i<elements.size(); i++)
         {
             auto element = elements.at(i);
@@ -408,7 +409,7 @@ void EnumCreator::computeNumberList(void)
 
         }// if we got a string from the xml
 
-        element.setNumber(stringValue);
+        element.setNumber(ProtocolParser::compressSum(stringValue));
 
         // keep track of maximum value
         if(value > maxValue)

--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -177,8 +177,8 @@ void EnumCreator::parse(void)
         // Now get the attributes
         QString value = ProtocolParser::getAttribute("value", map);
         QString comment = ProtocolParser::reflowComment(ProtocolParser::getAttribute("comment", map));
-        bool hiddenvalue = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("hidden", map));
-        bool ignorePrefix = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("ignorePrefix", map));
+        bool hiddenvalue = ProtocolParser::isFieldSet("hidden", map);
+        bool ignorePrefix = ProtocolParser::isFieldSet("ignorePrefix", map);
 
         // Add the enum prefix if applicable
         if ( !prefix.isEmpty() && !ignorePrefix )

--- a/enumcreator.h
+++ b/enumcreator.h
@@ -7,6 +7,29 @@
 #include "protocolsupport.h"
 #include "protocoldocumentation.h"
 
+class EnumCreator;
+
+class EnumElement : public ProtocolDocumentation
+{
+public:
+    EnumElement(ProtocolParser* parse, EnumCreator* creator, QString Parent, ProtocolSupport supported);
+
+    virtual void parse() override;
+
+    QString Name;
+    QString LookupName;
+    QString Value;
+    QString Comment;
+    QString Number;
+
+    bool IsHidden = false;
+    bool IgnoresPrefix = false;
+    bool IgnoresLookup = false;
+
+protected:
+    EnumCreator* parentEnum;
+};
+
 class EnumCreator : public ProtocolDocumentation
 {
 public:
@@ -19,7 +42,7 @@ public:
     void clear(void);
 
     //! Parse the DOM to fill out the enumeration list
-    virtual void parse(void);
+    virtual void parse() override;
 
     //! Parse the DOM to fill out the enumeration list for a global enum
     void parseGlobal(QString filename);
@@ -76,6 +99,9 @@ protected:
 
     //! Output file for source code file (may not be used)
     QString sourceOutput;
+
+    //! List of all the enumerated values
+    QList<EnumElement> elements;
 
     //! List of enumeration names
     QStringList nameList;

--- a/enumcreator.h
+++ b/enumcreator.h
@@ -11,23 +11,38 @@ class EnumCreator;
 
 class EnumElement : public ProtocolDocumentation
 {
+protected:
+    QString m_name;
+    QString m_lookupName;
+    QString m_value;
+    QString m_comment;
+    QString m_number;
+
+    bool m_isHidden = false;
+    bool m_ignoresPrefix = false;
+    bool m_ignoresLookup = false;
+
+    EnumCreator* parentEnum;
+
 public:
     EnumElement(ProtocolParser* parse, EnumCreator* creator, QString Parent, ProtocolSupport supported);
 
     virtual void parse() override;
+    virtual void checkAgainstKeywords() override;
 
-    QString Name;
-    QString LookupName;
-    QString Value;
-    QString Comment;
-    QString Number;
+    QString getName() const;
+    QString getLookupName() const;
+    QString getValue() const { return m_value; }
+    QString getDeclaration() const;
+    QString getComment() const { return m_comment; }
+    QString getNumber() const { return m_number; }
 
-    bool IsHidden = false;
-    bool IgnoresPrefix = false;
-    bool IgnoresLookup = false;
+    void setNumber(QString num) { m_number = num; }
 
-protected:
-    EnumCreator* parentEnum;
+    bool isHidden() const { return m_isHidden; }
+    bool ignoresPrefix() const { return m_ignoresPrefix; }
+    bool ignoresLookup() const { return m_ignoresLookup; }
+
 };
 
 class EnumCreator : public ProtocolDocumentation
@@ -61,6 +76,8 @@ public:
 
     //! Return the header file output string
     QString getOutput(void) const {return output;}
+
+    QString getPrefix() const { return prefix; }
 
     //! Return the source file output string
     QString getSourceOutput(void) const { return sourceOutput; }
@@ -102,21 +119,6 @@ protected:
 
     //! List of all the enumerated values
     QList<EnumElement> elements;
-
-    //! List of enumeration names
-    QStringList nameList;
-
-    //! List of enumeration comments
-    QStringList commentList;
-
-    //! List of enumeration values (as strings)
-    QStringList valueList;
-
-    //! List of enumeration values (as numbers)
-    QStringList numberList;
-
-    //! List of enumeration value hidden flags
-    QList<bool> hiddenList;
 
     //! A longer description is possible for enums (will be displayed in the documentation)
     QString description;

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -79,12 +79,12 @@ void ProtocolPacket::parse(void)
     QString defheadermodulename = ProtocolParser::getAttribute("deffile", map);
     encode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("encode", map));
     decode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("decode", map));
-    bool outputTopLevelStructureCode = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("useInOtherPackets", map));
+    bool outputTopLevelStructureCode = ProtocolParser::isFieldSet("useInOtherPackets", map);
 
     // Typically "parameterInterface" and "structureInterface" are only ever set to "true".
     // However we do handle the case where someone uses "false"
-    bool parameterFunctions = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("parameterInterface", map));
-    bool structureFunctions = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("structureInterface", map));
+    bool parameterFunctions = ProtocolParser::isFieldSet("parameterInterface", map);
+    bool structureFunctions = ProtocolParser::isFieldSet("structureInterface", map);
 
     if(ProtocolParser::isFieldClear(ProtocolParser::getAttribute("parameterInterface", map)))
     {

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1288,8 +1288,8 @@ bool ProtocolParser::isNumber(QString text, int &value)
 
 /**
  * @brief ProtocolParser::compressSum takes a string of summed elements
- * and attempts to compress them into a simpler element
- * e.g. "3 + CAT + DOG + 7" -> "CAT + DOG + 10"
+ * and attempts to compress them into a simpler element, with consistent formatting
+ * e.g. "0x13 + CAT + DOG+7" -> "CAT + DOG + 26"
  * @param text
  * @return
  */

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1225,6 +1225,66 @@ bool ProtocolParser::isFieldClear(QString value)
     return result;
 }
 
+bool ProtocolParser::isDecNum(QString text, int &value)
+{
+    bool ok = false;
+    int toVal = text.toInt(&ok);
+
+    if (ok)
+    {
+        value = toVal;
+        return true;
+    }
+
+    return false;
+}
+
+bool ProtocolParser::isHexNum(QString text, int &value)
+{
+    bool ok = false;
+
+    if (text.toLower().startsWith("0x"))
+    {
+        text.remove(0, 2);
+
+        int toVal = text.toInt(&ok, 16);
+
+        if (ok)
+        {
+            value = toVal;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ProtocolParser::isBinNum(QString text, int &value)
+{
+    bool ok = false;
+
+    if (text.toLower().startsWith("0b"))
+    {
+        text.remove(0,2);
+
+        int toVal = text.toInt(&ok, 2);
+
+        if (ok)
+        {
+            value = toVal;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ProtocolParser::isNumber(QString text, int &value)
+{
+    return isDecNum(text, value) ||
+           isHexNum(text, value) ||
+           isBinNum(text, value);
+}
 
 /*!
  * Get the string used for inline css. This must be bracketed in <style> tags in the html

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1330,6 +1330,15 @@ QString ProtocolParser::compressSum(QString text)
     {
         sum += QString::number(accum);
     }
+    else if ( sum.isEmpty() && accum == 0)
+    {
+        sum = "0";
+    }
+    else
+    {
+        // Should never get here
+        return text;
+    }
 
     return sum;
 }

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1286,6 +1286,54 @@ bool ProtocolParser::isNumber(QString text, int &value)
            isBinNum(text, value);
 }
 
+/**
+ * @brief ProtocolParser::compressSum takes a string of summed elements
+ * and attempts to compress them into a simpler element
+ * e.g. "3 + CAT + DOG + 7" -> "CAT + DOG + 10"
+ * @param text
+ * @return
+ */
+QString ProtocolParser::compressSum(QString text)
+{
+    QStringList elements = text.split("+");
+
+    QStringList texts;
+
+    int value = 0;
+    int count = 0;
+    int accum = 0;
+
+    // Test each element to see if it is numeric (or not)
+    for (QString element : elements)
+    {
+        element = element.trimmed();
+
+        if (isNumber(element, value))
+        {
+            count++;
+            accum += value;
+        }
+        else
+        {
+            texts.append(element);
+        }
+    }
+
+
+    QString sum = texts.join( " + " );
+
+    if ( !sum.isEmpty() && accum != 0)
+    {
+        sum += " + ";
+    }
+    if ( !sum.isEmpty() || accum != 0)
+    {
+        sum += QString::number(accum);
+    }
+
+    return sum;
+}
+
 /*!
  * Get the string used for inline css. This must be bracketed in <style> tags in the html
  * \return the inline csss string

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1168,6 +1168,10 @@ bool ProtocolParser::isFieldSet(const QDomElement &e, QString label)
     return isFieldSet(e.attribute(label).trimmed().toLower());
 }
 
+bool ProtocolParser::isFieldSet(QString value, QDomNamedNodeMap map)
+{
+    return isFieldSet(ProtocolParser::getAttribute(value,map));
+}
 
 /*!
  * Determine if the value of an attribute is either {'true','yes','1'}

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -118,8 +118,11 @@ public:
     //! Return true if the value set to {'true','yes','1'}
     static bool isFieldSet(QString value);
 
+    static bool isFieldSet(QString value, QDomNamedNodeMap map);
+
     //! Return true if the element has a particular attribute set to {'false','no','0'}
     static bool isFieldClear(const QDomElement &e, QString label);
+
 
     //! Return true if the value is set to {'false','no','0'}
     static bool isFieldClear(QString value);

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -123,9 +123,17 @@ public:
     //! Return true if the element has a particular attribute set to {'false','no','0'}
     static bool isFieldClear(const QDomElement &e, QString label);
 
-
     //! Return true if the value is set to {'false','no','0'}
     static bool isFieldClear(QString value);
+
+
+    /* Functions for converting a string to a numerical value */
+
+    static bool isDecNum(QString text, int& value);
+    static bool isHexNum(QString text, int& value);
+    static bool isBinNum(QString text, int& value);
+
+    static bool isNumber(QString text, int& value);
 
 protected:
 

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -135,6 +135,9 @@ public:
 
     static bool isNumber(QString text, int& value);
 
+    //! Take a sum of numbers (e.g. an enumeration value) and attempt to compress it
+    static QString compressSum(QString text);
+
 protected:
 
     //! Create the source and header files that represent a packet

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -88,7 +88,7 @@ void ProtocolStructure::parse(void)
     variableArray = ProtocolParser::getAttribute("variableArray", map);
     dependsOn = ProtocolParser::getAttribute("dependsOn", map);
     comment = ProtocolParser::reflowComment(ProtocolParser::getAttribute("comment", map));
-    hidden = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("hidden", map));
+    hidden = ProtocolParser::isFieldSet("hidden", map);
 
     if(name.isEmpty())
         name = "_unknown";

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -50,11 +50,11 @@ void ProtocolSupport::parse(const QDomNamedNodeMap& map)
         bitfield = false;
 
     // long bitfield support can be turned on
-    if(int64 && ProtocolParser::isFieldSet(ProtocolParser::getAttribute("supportLongBitfield", map)))
+    if(int64 && ProtocolParser::isFieldSet("supportLongBitfield", map))
         longbitfield = true;
 
     // bitfield test support can be turned on
-    if(ProtocolParser::isFieldSet(ProtocolParser::getAttribute("bitfieldTest", map)))
+    if(ProtocolParser::isFieldSet("bitfieldTest", map))
         bitfieldtest = true;
 
     // Global file names can be specified, but cannot have a "." in it


### PR DESCRIPTION
This PR provides a number of key improvements for enumeration handling:

1. The reverse-lookup which tries to extract a numerical value from previously defined data is significantly improved
   * It handles decimal / hex / binary numbers
   * It is now immune to whitespace padding
   * It can now lookup values that are defined within the same enum (as long as they are defined before they are referenced)
   * Multi-level lookups are reduced to a single element where possible. e.g. if ITEM1 is unknown, and ITEM2 is known to equal 4, then `"ITEM1 + 3 + ITEM2 + 7"` will be reduced to `"ITEM1 + 14`
   * Items that were previously left blank in the markdown now have the "best guess" filled in

1. Refactoring of the enumeration elements, into a separate EnumElement class. 

1. Refactored some ProtocolParser:: static functions for the sake of shorthand