### PR TITLE
Improved command-line argument parsing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -60,9 +60,9 @@ int main(int argc, char *argv[])
 
     if (!docs.isEmpty() && !argParser.isSet("no-markdown"))
     {
-        docs = ProtocolFile::sanitizePath(docs);
+        docs =  ProtocolFile::sanitizePath(docs);
 
-        if (QDir::current().mkdir(docs))
+        if (QDir(docs).exists() || QDir::current().mkdir(docs))
         {
             parser.setDocsPath(docs);
         }


### PR DESCRIPTION
- Errors on incorrect arguments
- Shows help message with -h
- Removes requirement for argument iteration and look-ahead
- Adds version information with -v
- Easier addition of extra options going forward