### PR TITLE
Fix to make sure 64-bit integer constants don't truncate to 32

### DIFF
--- a/fieldcoding.cpp
+++ b/fieldcoding.cpp
@@ -970,9 +970,9 @@ QString FieldCoding::integerDecodeFunction(int type, bool bigendian)
             {
             default:
             case 3: function += "0x00800000;\n"; break;
-            case 5: function += "0x0000008000000000;\n"; break;
-            case 6: function += "0x0000800000000000;\n"; break;
-            case 7: function += "0x0080000000000000;\n"; break;
+            case 5: function += "0x0000008000000000LL;\n"; break;
+            case 6: function += "0x0000800000000000LL;\n"; break;
+            case 7: function += "0x0080000000000000LL;\n"; break;
             }
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,4 @@
-#include <QCommandlineParser>
+#include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QDomDocument>
 #include <QStringList>

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -1,6 +1,8 @@
 #include "protocolsupport.h"
 #include "protocolparser.h"
 
+#include <QStringList>
+
 ProtocolSupport::ProtocolSupport() :
     maxdatasize(0),
     int64(true),


### PR DESCRIPTION
Without the `LL` extension, all integer constants are 32 bits, which was causing these values to be truncated to zero.