### PR TITLE
Added structureSufffix for structure naming

### DIFF
--- a/encodable.h
+++ b/encodable.h
@@ -183,6 +183,7 @@ public:
     //! String frequently reused for the beginning of decode functions
     static const QString INT_DECODE;
 
+    QString structureSuffix;//!< Suffix added when defining a structure for this encodable
     QString typeName;       //!< The type name of this encodable, like "uint8_t" or "myStructure_t"
     QString array;          //!< The array length of this encodable, empty if no array
     QString array2d;        //!< The second dimension array length of this encodable, empty if no 2nd dimension

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -25,6 +25,8 @@ ProtocolPacket::ProtocolPacket(ProtocolParser* parse, ProtocolSupport supported,
 {
     // These are attributes on top of the normal structureModule that we support
     attriblist << "structureInterface" << "parameterInterface" << "ID" << "useInOtherPackets";
+
+    structureSuffix = "_packet";
 }
 
 

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -112,7 +112,7 @@ void ProtocolStructure::parse(void)
     testAndWarnAttributes(map, attriblist);
 
     // for now the typename is derived from the name
-    typeName = support.prefix + name + "_t";
+    typeName = support.prefix + name + structureSuffix + "_t";
 
     // We can't have a variable array length without an array
     if(array.isEmpty() && !variableArray.isEmpty())


### PR DESCRIPTION
This PR adds the suffix '_packet_t' to structures automatically created based on a packet, rather than simply '_t'

e.g. a packet defined as

```
<Packet name="Test">
 <Data name="a" inMemoryType="unsigned16"/>
</Packet>
```

will be structured as:

```
typedef struct
{
  uint16_t a;
} Test_packet_t;