### PR TITLE
Fix for erroneous "_t" check

### DIFF
--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -1599,7 +1599,7 @@ void ProtocolField::getIncludeDirectives(QStringList& list) const
                 if (include.endsWith("_t"))
                 {
                     // Remove the last two characters
-                    include.chop(include.size()-2);
+                    include.chop(2);
                 }
 
                 include += ".h";

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -130,9 +130,11 @@ QString TypeData::toTypeString(QString enumName, QString structName) const
     {
         typeName = structName;
 
-        // Make user it ends with "_t";
-        if(!typeName.contains("_t"))
+        // Make sure it ends with "_t";
+        if(!typeName.endsWith("_t"))
+        {
             typeName += "_t";
+        }
     }
     else
     {
@@ -1593,10 +1595,16 @@ void ProtocolField::getIncludeDirectives(QStringList& list) const
             {
                 // In this case, we guess at the include name
                 include = typeName;
-                include.remove("_t");
+
+                if (include.endsWith("_t"))
+                {
+                    // Remove the last two characters
+                    include.chop(include.size()-2);
+                }
+
                 include += ".h";
                 list.append(include);
-                emitWarning("unknown include for " + typeName + "; guess supplied");
+                emitWarning("unknown include for '" + typeName + "'; guess supplied - '" + include + "'");
             }
 
         }


### PR DESCRIPTION
Current release has a bug whereby structures that contain text `_t` within their name generate bad code.

This is because there are two checks in ProtoGen to see if the text _contains_ `_t` where they should check if the text _**ends with**_ `_t`

- Struct names were checked to see if they contained text "_t"
- Instead, should have been checked if the name endsWith("_t")
- Caused erroneous behaviour when struct name contained text "_t" e.g. "my_struct_test"