### PR TITLE
Added extra CLI options for Protogen

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ ProtoGen is a C++/Qt5 compiled command line application, suitable for inclusion 
 
 - `Style.css` will replace the default inline css in the markdown documentation with the contents of the Style.css file.
 
+- `-no-css` will cause ProtoGen to skip output of CSS data in generated documentation files.
+
 - `-no-unrecognized-warnings` will suppress warnings about unrecognized tags or attributes in the `Protocol.xml` file. This is useful if you add data to your xml that you expect Protogen to ignore. 
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ ProtoGen is a C++/Qt5 compiled command line application, suitable for inclusion 
 
 - `-no-markdown` will cause ProtoGen to skip the output of the user level html documentation. 
 
+- `-no-about-section` will cause ProtoGen to skip the output of extra preface and postface information in the generated documentation.
+
 - `-no-helper-files` will cause ProtoGen to skip the output of files not directly specified by the protocol.xml. 
 
 - `Style.css` will replace the default inline css in the markdown documentation with the contents of the Style.css file.

--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char *argv[])
     argParser.addOption({"no-about-section", "Skip generation of \"About this ICD\" section in documentation output"});
     argParser.addOption({"no-helper-files", "Skip creation of helper files not directly specifed by protocol .xml file"});
     argParser.addOption({{"s", "style"}, "Specify a css file to override the default style for HTML documentation", "cssfile"});
+    argParser.addOption({"no-css", "Skip generation of any css data in documentation files"});
     argParser.addOption({"no-unrecognized-warnings", "Suppress warnings for unrecognized xml tags"});
 
     argParser.process(a);
@@ -89,6 +90,7 @@ int main(int argc, char *argv[])
     parser.showHiddenItems(argParser.isSet("show-hidden-items"));
     parser.disableUnrecognizedWarnings(argParser.isSet("no-unrecognized-warnings"));
     parser.setLaTeXSupport(argParser.isSet("latex"));
+    parser.disableCSS(argParser.isSet("no-css"));
 
     QString latexLevel = argParser.value("latex-header-level");
 

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
     argParser.addOption({{"l", "latex-header-level"}, "LaTeX header level", "latexlevel"});
     argParser.addOption({"no-doxygen", "Skip generation of developer-level documentation"});
     argParser.addOption({"no-markdown", "Skip generation of user-level documentation"});
+    argParser.addOption({"no-about-section", "Skip generation of \"About this ICD\" section in documentation output"});
     argParser.addOption({"no-helper-files", "Skip creation of helper files not directly specifed by protocol .xml file"});
     argParser.addOption({{"s", "style"}, "Specify a css file to override the default style for HTML documentation", "cssfile"});
     argParser.addOption({"no-unrecognized-warnings", "Suppress warnings for unrecognized xml tags"});
@@ -84,6 +85,7 @@ int main(int argc, char *argv[])
     parser.disableDoxygen(argParser.isSet("no-doxygen"));
     parser.disableMarkdown(argParser.isSet("no-markdown"));
     parser.disableHelperFiles(argParser.isSet("no-helper-files"));
+    parser.disableAboutSection(argParser.isSet("no-about-section"));
     parser.showHiddenItems(argParser.isSet("show-hidden-items"));
     parser.disableUnrecognizedWarnings(argParser.isSet("no-unrecognized-warnings"));
     parser.setLaTeXSupport(argParser.isSet("latex"));

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -993,7 +993,17 @@ QString ProtocolPacket::getTopLevelMarkdown(bool global, const QStringList& pack
         // The column headings
         bytes.append("Bytes");
         names.append("Name");
-        encodings.append("[Enc](#Enc)");
+
+        if (parser->hasAboutSection())
+        {
+            encodings.append("[Enc](#Enc)");
+        }
+        else
+        {
+            // Disable linking if there's nothing to link to
+            encodings.append("Enc");
+        }
+
         repeats.append("Repeat");
         comments.append("Description");
 

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -1170,7 +1170,7 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
     }
 
     /* Write protocol introductory information */
-    if (!noAboutSection)
+    if (hasAboutSection())
     {
         if(title.isEmpty())
             file.write("# " + name + " Protocol\n");

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -29,7 +29,8 @@ ProtocolParser::ProtocolParser() :
     nohelperfiles(false),
     nodoxygen(false),
     noAboutSection(false),
-    showAllItems(false)
+    showAllItems(false),
+    nocss(false)
 {
 }
 
@@ -1149,27 +1150,34 @@ void ProtocolParser::outputMarkdown(bool isBigEndian, QString inlinecss)
         file.write("\n");
     }
 
-    // Open the style tag
-    file.write("<style>\n");
+    /* Add stylesheet information
+     * (unless it is disabled entirely)
+     */
+    if (!nocss)
+    {
+        // Open the style tag
+        file.write("<style>\n");
 
-    if(inlinecss.isEmpty())
-        file.write(getDefaultInlinCSS());
-    else
-        file.write(inlinecss);
+        if(inlinecss.isEmpty())
+            file.write(getDefaultInlinCSS());
+        else
+            file.write(inlinecss);
 
-    // Close the style tag
-    file.write("</style>\n");
+        // Close the style tag
+        file.write("</style>\n");
 
-    file.write("\n");
-    if(title.isEmpty())
-        file.write("# " + name + " Protocol\n");
-    else
-        file.write("# " + title + "\n");
-    file.write("\n");
+        file.write("\n");
+    }
 
     /* Write protocol introductory information */
     if (!noAboutSection)
     {
+        if(title.isEmpty())
+            file.write("# " + name + " Protocol\n");
+        else
+            file.write("# " + title + "\n");
+        file.write("\n");
+
 
         if(!comment.isEmpty())
         {

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -43,6 +43,9 @@ public:
     //! Option to disable 'about this ICD' section
     void disableAboutSection(bool disable) { noAboutSection = disable; }
 
+    //! Return status of 'About this ICD' section
+    bool hasAboutSection() const { return !noAboutSection; }
+
     //! Option to force documentation for hidden items
     void showHiddenItems(bool show) {showAllItems = show;}
 

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -52,6 +52,9 @@ public:
     //! Set the inlinee css
     void setInlineCSS(QString css) {inlinecss = css;}
 
+    //! Disable CSS entirely
+    void disableCSS(bool disable) { nocss = disable; }
+
     //! Parse the DOM from the xml file(s). This kicks off the auto code generation for the protocol
     bool parse(QString filename, QString path, QStringList otherfiles);
 
@@ -161,6 +164,7 @@ protected:
     bool noAboutSection;//!< Disable extra 'about' section in the generated documentation
     bool showAllItems;  //!< Generate documentation even for elements with 'hidden="true"'
     QString inlinecss;  //!< CSS used for markdown output
+    bool nocss;         //!< Disable all CSS output
 
     QStringList filesparsed;
     QList<XMLLineLocator*>lines;

--- a/protocolparser.h
+++ b/protocolparser.h
@@ -40,6 +40,9 @@ public:
     //! Option to disable doxygen output
     void disableDoxygen(bool disable) {nodoxygen = disable;}
 
+    //! Option to disable 'about this ICD' section
+    void disableAboutSection(bool disable) { noAboutSection = disable; }
+
     //! Option to force documentation for hidden items
     void showHiddenItems(bool show) {showAllItems = show;}
 
@@ -155,6 +158,7 @@ protected:
     bool nomarkdown;    //!< Disable markdown output
     bool nohelperfiles; //!< Disable helper file output
     bool nodoxygen;     //!< Disable doxygen output
+    bool noAboutSection;//!< Disable extra 'about' section in the generated documentation
     bool showAllItems;  //!< Generate documentation even for elements with 'hidden="true"'
     QString inlinecss;  //!< CSS used for markdown output
 
@@ -168,6 +172,9 @@ protected:
     QList<EnumCreator*> globalEnums;
     QString inputpath;
     QString inputfile;
+
+    //! Write "About this ICD" section to file
+    void WriteAboutSection(ProtocolFile& file, bool isBigEndian);
 
 private:
 


### PR DESCRIPTION
`-no-about-section` - Hides the "About this ICD" section and the version information at the start of the output documentation. Useful for generating protocol files piecemeal and merging them together in a custom fashion

`-no-css` - Completely disables CSS in output documentation (for same reasons as above).