### PR TITLE
Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The Protocol tag supports the following attributes:
 
 - `printfile` : Optional attribute that gives the name of the source and header file (.cpp and .h) that will be used for the text print and text read code output; except for any objects which have their own `printfile` attribute. Presence of the global printfile attribute enables the text print output for all packets and structures.
 
+- `mapfile` : Optional attribute that gives the name of the source and header file (.cpp and .h) that will be used for encoding and decoding structure objects to a key:value map; except for any objects which have their own `mapfile` attribute set.
+
 - `prefix` : A string that can be used to prepend structure and file names. This is typically left out, but if a single project uses multiple ProtoGen protocols then it may be useful to give them different prefixes to avoid namespace collisions.
 
 - `maxSize` : A number that specifies the maximum number of data bytes that a packet can support. If this is provided, and is greater than zero, ProtoGen will issue a warning for any packet whose maximum encoded size is greater than this.
@@ -303,11 +305,15 @@ Structure tag Attributes:
 
 - `print` : By default text print and text read functions will not be output. Set `print="true"` to enable the text function output. The functions will be output to the `prefix + name + "Print"` module, unless the `printfile` attribute or global `printfile` attribute is given.
 
+- `map` : By default, map encode and decode functions will not be output. Set `map="true"` to enable the map function output. The functions will be output to the `prefix + name + "Map"` module, unless the `mapfile` attribute or global `mapfile` attribute is given.
+
 - `verifyfile` : Optional attribute used to specify a module which receives both the init and verify functions (only if verification or initialization values exist for a member field). If `verifyfile` is omitted then the init and verify functions are output in the normal file. As with other file attributes the verify file will be correctly appended if it is used multiple times.
 
 - `comparefile` : Optional attribute used to specify a c++ module that implements a comparison function. The comparison functions compare the structure element by element and generate a human readable string report to indicate which elements are different. String handling is provided by Qt's QString (which is why this is a c++ module separate from the other output files). Presence of the `comparefile` attribute enables the compare output.
 
 - `printfile` : Optional attribute used to specify a c++ module that implements functions to text print and text read the contents of a structure. String handling is provided by Qt's QString (which is why this is a c++ module separate from the other output files). Presence of the `printfile` attribute enables the output.
+
+- `mapfile` : Optional attribute used to specify a c++ module that implements functions to encode and decode the contents of a structure to a key:value map. Map handling is provided by Qt's QMap class. Presence of the `mapfile` attribute enables the output.
 
 - `redefine` : It is possible to create multiple encodings for an existing structure definition by using the redefine attribute to reference a previously defined structure. When doing this the structure itself will not be declared, but the encoding and decoding functions will. This requires that the encoding rules must have fields with the same names and in-memory types as the referenced structure.
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ Data subtag attributes:
 
 - `comment` : A one line doxygen comment that follows the data declaration.
 
+- `map` : If mapEncode and mapDecode functions are defined for this struct or packet, this tag can be used to specify if each individual field is encoded or decoded to the map. By default (and if this tag is not present) the field will be both encoded and decoded. If this tag is set to `encode` then the field will only be encoded. If this tag is set to `decode` then the field will only be decoded. If this tag is set to `false` then the field will not be encoded or decoded.
+
 - `range | units | notes` : If specified, each of these attributes will be added (as single-line comments) to the packet description table in the documentation markdown. These comments will appear next to this <Data> tag, and can be used if extra specificity is required. Note that these fields apply *only* to the documentation, and will not appear anywhere in the generated code.
 
 Documentation tag

--- a/encodable.h
+++ b/encodable.h
@@ -94,6 +94,12 @@ public:
     //! Get the string used for text reading this field.
     virtual QString getTextReadString(bool isStructureMember) const {Q_UNUSED(isStructureMember); return QString();}
 
+    //! Get the string used to encode this field to a map
+    virtual QString getMapEncodeString(bool isStructureMember) const {Q_UNUSED(isStructureMember); return QString();}
+
+    //! Get the string used to decode this field from a map
+    virtual QString getMapDecodeString(bool isStructureMember) const {Q_UNUSED(isStructureMember); return QString();}
+
     //! Return true if this encodable has documentation for markdown output
     virtual bool hasDocumentation(void) {return true;}
 

--- a/exampleprotocol.xml
+++ b/exampleprotocol.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<Protocol name="Demolink" title="Demonstration of protogen" prefix="" file="linkcode" comparefile="compare/compareDemolink" printfile="compare/printDemolink" verifyfile="definitions/verify" pointer="testPacket_t" maxSize="1000" api="1" version="1.0.0.a" endian="little" supportLongBitfield="true" bitfieldTest="true" comment=
+<Protocol name="Demolink" title="Demonstration of protogen" prefix="" file="linkcode" mapfile="map/mapDemolink" comparefile="compare/compareDemolink" printfile="compare/printDemolink" verifyfile="definitions/verify" pointer="testPacket_t" maxSize="1000" api="1" version="1.0.0.a" endian="little" supportLongBitfield="true" bitfieldTest="true" comment=
 "This is an demonstration protocol definition. This file demonstrates most things
 that the ProtoGen application can do regarding automatic protocol packing/upacking
 code generation.

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -2811,8 +2811,6 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
         }
     }// else numeric output
 
-#warning "Implement this";
-
     return output;
 }
 

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -2641,6 +2641,7 @@ QString ProtocolField::getMapEncodeString(bool isStructureMember) const
 
 QString ProtocolField::getMapDecodeString(bool isStructureMember) const
 {
+    QString key;
     QString output;
 
     if(inMemoryType.isNull || encodedType.isNull)
@@ -2655,7 +2656,12 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
 
     if(inMemoryType.isString)
     {
-#warning "implement string decode"
+        key = "_pg_prefix + \"" + name + "\"";
+
+        output += TAB_IN + "key = " + key + ";\n\n";
+
+        output += TAB_IN + "if (_pg_map.contains(key))\n";
+        output += TAB_IN + TAB_IN + "strncpy(" + access + ", _pg_map[key].toLatin1().constData(), " + array + ");\n";
     }
     else
     {
@@ -2710,8 +2716,6 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
         }// data type is a struct
         else
         {
-            // Construct the map key
-            QString key;
 
             key = "_pg_prefix + \"" + name + "\"";
 

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -2548,7 +2548,7 @@ QString ProtocolField::getMapEncodeString(bool isStructureMember) const
 
     if(inMemoryType.isString)
     {
-        output += TAB_IN + "_pg_map[_pg_prefix + \"" + name + "\"] = QString(" + access + ");\n";
+        output += TAB_IN + "_pg_map[_pg_prename + \":" + name + "\"] = QString(" + access + ");\n";
     }
     else
     {
@@ -2592,7 +2592,7 @@ QString ProtocolField::getMapEncodeString(bool isStructureMember) const
 
         if(inMemoryType.isStruct)
         {
-            output += spacing + "mapEncode" + typeName + "(_pg_prefix + \"" + name + "\"";
+            output += spacing + "mapEncode" + typeName + "(_pg_prename + \":" + name + "\"";
 
             if(isArray())
                 output += " + \"[\" + QString::number(_pg_i) + \"]\"";
@@ -2603,7 +2603,7 @@ QString ProtocolField::getMapEncodeString(bool isStructureMember) const
         }// data type is a struct
         else
         {
-            output += spacing + "_pg_map[_pg_prefix + \"" + name + "\"";
+            output += spacing + "_pg_map[_pg_prename + \":" + name + "\"";
 
             if(isArray())
                 output += " + \"[\" + QString::number(_pg_i) + \"]\"";
@@ -2656,7 +2656,7 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
 
     if(inMemoryType.isString)
     {
-        key = "_pg_prefix + \"" + name + "\"";
+        key = "_pg_prename + \":" + name + "\"";
 
         output += TAB_IN + "key = " + key + ";\n\n";
 
@@ -2705,7 +2705,7 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
 
         if(inMemoryType.isStruct)
         {
-            output += spacing + "mapDecode" + typeName + "(_pg_prefix + \"" + name + "\"";
+            output += spacing + "mapDecode" + typeName + "(_pg_prename + \":" + name + "\"";
 
             if(isArray())
                 output += " + \"[\" + QString::number(_pg_i) + \"]\"";
@@ -2717,7 +2717,7 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
         else
         {
 
-            key = "_pg_prefix + \"" + name + "\"";
+            key = "_pg_prename + \":" + name + "\"";
 
             if(isArray())
                 key += " + \"[\" + QString::number(_pg_i) + \"]\"";

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -2553,6 +2553,10 @@ QString ProtocolField::getMapEncodeString(bool isStructureMember) const
 {  
     QString output;
 
+    // Cannot encode to a null memory type
+    if(inMemoryType.isNull)
+        return output;
+
     // Return empty string if this field should not be encoded to map
     if((mapOptions & MAP_ENCODE) == 0)
         return output;
@@ -2669,6 +2673,10 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
     QString key;
     QString output;
     QString decode;
+
+    // Cannot decode to a null memory type
+    if(inMemoryType.isNull)
+        return output;
 
     // Return empty string if this field is not to be decoded
     if((mapOptions & MAP_DECODE) == 0)

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -2001,6 +2001,9 @@ bool ProtocolField::hasInit(void) const
  */
 QString ProtocolField::getVerifyString(bool isStructureMember) const
 {
+    if(!hasVerify())
+        return QString();
+
     // No verify for null or string
     if(inMemoryType.isNull || inMemoryType.isString)
         return QString();
@@ -2834,6 +2837,9 @@ QString ProtocolField::getSetToDefaultsString(bool isStructureMember) const
 QString ProtocolField::getSetInitialValueString(bool isStructureMember) const
 {
     QString output;
+
+    if(!hasInit())
+        return output;
 
     if(inMemoryType.isNull)
         return output;

--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -2615,10 +2615,11 @@ QString ProtocolField::getMapEncodeString(bool isStructureMember) const
 
             output += "] = ";
 
+            // Numeric values are automatically converted to correct QVariant types
             if(inMemoryType.isFloat || !printScalerString.isEmpty())
-                output += "QString::number(" + access + printScalerString + ", 'g', 16)";
+                output += access + printScalerString;
             else
-                output += "QString::number(" + access + ")";
+                output += access;
 
             output += ";\n";
 
@@ -2668,7 +2669,7 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
         output += TAB_IN + "key = " + key + ";\n\n";
 
         output += TAB_IN + "if (_pg_map.contains(key))\n";
-        output += TAB_IN + TAB_IN + "strncpy(" + access + ", _pg_map[key].toLatin1().constData(), " + array + ");\n";
+        output += TAB_IN + TAB_IN + "strncpy(" + access + ", _pg_map[key].toString().toLatin1().constData(), " + array + ");\n";
     }
     else
     {
@@ -2756,7 +2757,11 @@ QString ProtocolField::getMapDecodeString(bool isStructureMember) const
 
             output += spacing + "if(_pg_map.contains(key))\n";
             output += spacing + "{\n";
-            output += spacing + TAB_IN + decode + "(&ok);\n";
+            output += spacing + TAB_IN + decode + "(&ok)";
+
+            if(inMemoryType.isFloat && !printScalerString.isEmpty())
+                output += readScalerString;
+            output += ";\n";
             output += spacing + TAB_IN + "if(ok)\n";
             output += spacing + TAB_IN + TAB_IN + access + " = " + decode + "();\n";
             output += spacing + "}\n";

--- a/protocolfield.h
+++ b/protocolfield.h
@@ -82,6 +82,15 @@ class ProtocolField : public Encodable
 {
 public:
 
+    // Option enumeration for determining if a certain field should be encoded / decoded
+    enum MapOptions
+    {
+        MAP_NONE,   // Do not encode or decode this field
+        MAP_ENCODE, // Only encode this field
+        MAP_DECODE, // Only decode this field
+        MAP_BOTH    // Encode and decode this field
+    };
+
     //! Construct a field, setting the protocol name and name prefix
     ProtocolField(ProtocolParser* parse, QString parent, ProtocolSupport supported);
 
@@ -339,6 +348,9 @@ protected:
 
     //! Indicates if this field is hidden from documentation
     bool hidden;
+
+    //! Indicates the map encode / decode settings for this field
+    int mapOptions;
 
     //! Extract the type information from the type string
     void extractType(TypeData& data, const QString& typeString, const QString& name, bool inMemory);

--- a/protocolfield.h
+++ b/protocolfield.h
@@ -178,6 +178,12 @@ public:
     //! Get the string used for text reading this field.
     virtual QString getTextReadString(bool isStructureMember) const Q_DECL_OVERRIDE;
 
+    //! Get the string used for map encoding this field
+    virtual QString getMapEncodeString(bool isStructureMember) const Q_DECL_OVERRIDE;
+
+    //! Get the string used for map decoding this field
+    virtual QString getMapDecodeString(bool isStructureMember) const Q_DECL_OVERRIDE;
+
     //! Return the string that sets this encodable to its initial value in code
     virtual QString getSetInitialValueString(bool isStructureMember) const Q_DECL_OVERRIDE;
 

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -85,6 +85,8 @@ void ProtocolPacket::parse(void)
     decode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("decode", map));
     compare = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("compare", map));
     print = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("print", map));
+    mapEncode = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("map", map));
+
     bool outputTopLevelStructureCode = ProtocolParser::isFieldSet("useInOtherPackets", map);
     QString redefinename = ProtocolParser::getAttribute("redefine", map);
 

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -79,6 +79,8 @@ void ProtocolPacket::parse(void)
     QString verifymodulename = ProtocolParser::getAttribute("verifyfile", map);
     QString comparemodulename = ProtocolParser::getAttribute("comparefile", map);
     QString printmodulename = ProtocolParser::getAttribute("printfile", map);
+    QString mapmodulename = ProtocolParser::getAttribute("mapfile", map);
+
     encode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("encode", map));
     decode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("decode", map));
     compare = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("compare", map));
@@ -171,7 +173,7 @@ void ProtocolPacket::parse(void)
     // Most of the file setup work, note that we do not declare a structure in
     // the event that it has only one member and we are not doing structure
     // interfaces to the encode/decode routines
-    setupFiles(moduleName, defheadermodulename, verifymodulename, comparemodulename, printmodulename, structureFunctions, false, redefines);
+    setupFiles(moduleName, defheadermodulename, verifymodulename, comparemodulename, printmodulename, mapmodulename, structureFunctions, false, redefines);
 
     // The functions that include structures which are children of this
     // packet. These need to be declared before the main functions

--- a/protocolpacket.cpp
+++ b/protocolpacket.cpp
@@ -250,6 +250,27 @@ void ProtocolPacket::parse(void)
             structureFunctions = true;
         }
 
+        if(mapEncode)
+        {
+            if (redefines == NULL)
+            {
+                mapHeader.makeLineSeparator();
+                mapHeader.write(getMapEncodeFunctionPrototype(false));
+                mapHeader.makeLineSeparator();
+                mapHeader.write(getMapDecodeFunctionPrototype(false));
+                mapHeader.makeLineSeparator();
+
+                mapSource.makeLineSeparator();
+                mapSource.write(getMapEncodeFunctionString(false));
+                mapSource.makeLineSeparator();
+                mapSource.write(getMapDecodeFunctionString(false));
+                mapSource.makeLineSeparator();
+            }
+
+            // Must have structure functions to do map encode/decode
+            structureFunctions = true;
+        }
+
     }
 
     // The functions that encode and decode the packet from a structure.
@@ -293,6 +314,12 @@ void ProtocolPacket::parse(void)
     {
         printHeader.flush();
         printSource.flush();
+    }
+
+    if(mapEncode)
+    {
+        mapHeader.flush();
+        mapSource.flush();
     }
 
 }// ProtocolPacket::parse

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -260,6 +260,10 @@ bool ProtocolParser::parse(QString filename, QString path, QStringList otherfile
         filePathList.append(module->getPrintSourceFilePath());
         fileNameList.append(module->getPrintHeaderFileName());
         filePathList.append(module->getPrintHeaderFilePath());
+        fileNameList.append(module->getMapSourceFileName());
+        filePathList.append(module->getMapSourceFilePath());
+        fileNameList.append(module->getMapHeaderFileName());
+        filePathList.append(module->getMapHeaderFilePath());
 
     }// for all top level structures
 
@@ -299,6 +303,10 @@ bool ProtocolParser::parse(QString filename, QString path, QStringList otherfile
         filePathList.append(packet->getPrintSourceFilePath());
         fileNameList.append(packet->getPrintHeaderFileName());
         filePathList.append(packet->getPrintHeaderFilePath());
+        fileNameList.append(packet->getMapSourceFileName());
+        filePathList.append(packet->getMapSourceFilePath());
+        fileNameList.append(packet->getMapHeaderFileName());
+        filePathList.append(packet->getMapHeaderFilePath());
 
     }
 
@@ -332,6 +340,10 @@ bool ProtocolParser::parse(QString filename, QString path, QStringList otherfile
         filePathList.append(packet->getPrintSourceFilePath());
         fileNameList.append(packet->getPrintHeaderFileName());
         filePathList.append(packet->getPrintHeaderFilePath());
+        fileNameList.append(packet->getMapSourceFileName());
+        filePathList.append(packet->getMapSourceFilePath());
+        fileNameList.append(packet->getMapHeaderFileName());
+        filePathList.append(packet->getMapHeaderFilePath());
 
     }
 

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -2131,8 +2131,6 @@ QString ProtocolStructure::getMapEncodeString(bool isStructureMember) const
     if(!comment.isEmpty())
         output += TAB_IN + "// " + comment + "\n";
 
-    std::cout << name.toStdString() << " - getMapEncodeString\n";
-
     if(isArray())
     {
 
@@ -2286,9 +2284,6 @@ QString ProtocolStructure::getMapDecodeString(bool isStructureMember) const
     if(!comment.isEmpty())
         output += TAB_IN + "// " + comment + "\n";
 
-    std::cout << name.toStdString() << " - getMapDecodeString\n";
-
-#warning "Complete this! (Is it even used?)"
 
     if(isArray())
     {

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -2250,13 +2250,14 @@ QString ProtocolStructure::getMapDecodeFunctionString(bool includeChildren) cons
     output += "void mapDecode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, " + structName + "* _pg_user)\n";
     output += "{\n";
 
+    output += TAB_IN + "QString key;  // Temporary map key variable\n";
+    output += TAB_IN + "bool ok = false;  // Temporary data validation variable\n";
+
     if(needsDecodeIterator)
-        output += TAB_IN + "unsigned _pg_i = 0;\n";
+        output += TAB_IN + "unsigned _pg_i = 0;  // Array iterator\n";
 
     if(needs2ndDecodeIterator)
-        output += TAB_IN + "unsigned _pg_j = 0;\n";
-
-    output += TAB_IN + "QString key;\n\n";
+        output += TAB_IN + "unsigned _pg_j = 0; // Secondary array iterator\n";
 
     for(int i=0; i<encodables.length(); i++)
     {

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -2099,11 +2099,6 @@ QString ProtocolStructure::getMapEncodeFunctionString(bool includeChildren) cons
     if(needs2ndDecodeIterator)
         output += TAB_IN + "unsigned _pg_j = 0;\n";
 
-    output += TAB_IN + "QString _pg_prefix = _pg_prename;\n";
-
-    output += TAB_IN + "if(!_pg_prefix.isEmpty() && !_pg_prefix.endsWith(':'))\n";
-    output += TAB_IN + TAB_IN + "_pg_prefix += \":\";\n";
-
     for(int i=0; i<encodables.length(); i++)
     {
         ProtocolFile::makeLineSeparator(output);
@@ -2264,11 +2259,6 @@ QString ProtocolStructure::getMapDecodeFunctionString(bool includeChildren) cons
         output += TAB_IN + "unsigned _pg_j = 0;\n";
 
     output += TAB_IN + "QString key;\n\n";
-
-    output += TAB_IN + "QString _pg_prefix = _pg_prename;\n";
-
-    output += TAB_IN + "if(!_pg_prefix.isEmpty() && !_pg_prefix.endsWith(':'))\n";
-    output += TAB_IN + TAB_IN + "_pg_prefix += \":\";\n";
 
     for(int i=0; i<encodables.length(); i++)
     {

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -2048,7 +2048,7 @@ QString ProtocolStructure::getMapEncodeFunctionPrototype(bool includeChildren) c
     // My mapEncode function
 
     output += "//! Encode the contents of a " + typeName + " structure to a string Key:Value map\n";
-    output += "void mapEncode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, const " + structName + "* _pg_user);\n";
+    output += "void mapEncode" + typeName + "(const QString& _pg_prename, QVariantMap& _pg_map, const " + structName + "* _pg_user);\n";
 
     return output;
 }// ProtocolStructure::getMapEncodeFunctionPrototype
@@ -2090,7 +2090,7 @@ QString ProtocolStructure::getMapEncodeFunctionString(bool includeChildren) cons
     output += " * \\param _pg_user is the structure to encode\n";
     output += " */\n";
 
-    output += "void mapEncode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, const " + structName + "* _pg_user)\n";
+    output += "void mapEncode" + typeName + "(const QString& _pg_prename, QVariantMap& _pg_map, const " + structName + "* _pg_user)\n";
     output += "{\n";
 
     if(needsDecodeIterator)
@@ -2210,7 +2210,7 @@ QString ProtocolStructure::getMapDecodeFunctionPrototype(bool includeChildren) c
     // My mapEncode function
 
     output += "//! Decode the contents of a " + typeName + " structure from a string Key:Value map\n";
-    output += "void mapDecode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, " + structName + "* _pg_user);\n";
+    output += "void mapDecode" + typeName + "(const QString& _pg_prename, QVariantMap& _pg_map, " + structName + "* _pg_user);\n";
 
     return output;
 }// ProtocolStructure::getMapDecodeeFunctionPrototype
@@ -2247,7 +2247,7 @@ QString ProtocolStructure::getMapDecodeFunctionString(bool includeChildren) cons
     output += " * \\param _pg_user is the structure to encode\n";
     output += " */\n";
 
-    output += "void mapDecode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, " + structName + "* _pg_user)\n";
+    output += "void mapDecode" + typeName + "(const QString& _pg_prename, QVariantMap& _pg_map, " + structName + "* _pg_user)\n";
     output += "{\n";
 
     output += TAB_IN + "QString key;  // Temporary map key variable\n";

--- a/protocolstructure.cpp
+++ b/protocolstructure.cpp
@@ -2014,6 +2014,341 @@ QString ProtocolStructure::getTextReadString(bool isStructureMember) const
 }// ProtocolStructure::getTextReadString
 
 
+/*!
+ * Return the string that gives the prototype of the function used to encode this structure to a map
+ * \param includeChildren should be true to include the function prototypes of the child structures
+ * \return the function prototype string, which may be empty
+ */
+QString ProtocolStructure::getMapEncodeFunctionPrototype(bool includeChildren) const
+{
+    QString output;
+
+    if(getNumberOfEncodeParameters() == 0)
+    {
+        return output;
+    }
+
+    if(includeChildren)
+    {
+        for(int i = 0; i < encodables.length();  i++)
+        {
+            ProtocolStructure* structure = dynamic_cast<ProtocolStructure*>(encodables.at(i));
+
+            if(!structure)
+                continue;
+
+            ProtocolFile::makeLineSeparator(output);
+
+            output += structure->getMapEncodeFunctionPrototype(includeChildren);
+        }
+
+        ProtocolFile::makeLineSeparator(output);
+    }
+
+    // My mapEncode function
+
+    output += "//! Encode the contents of a " + typeName + " structure to a string Key:Value map\n";
+    output += "void mapEncode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, const " + structName + "* _pg_user);\n";
+
+    return output;
+}// ProtocolStructure::getMapEncodeFunctionPrototype
+
+
+/*!
+ * Return the string that gives the function used to encode this structure to a map
+ * \param includeChildren should be true to include the functions of the child structures
+ * \return the function string, which may be empty
+ */
+QString ProtocolStructure::getMapEncodeFunctionString(bool includeChildren) const
+{
+    QString output;
+
+    if(getNumberOfDecodeParameters() == 0)
+        return output;
+
+    if(includeChildren)
+    {
+        for(int i = 0; i < encodables.length(); i++)
+        {
+            ProtocolStructure* structure = dynamic_cast<ProtocolStructure*>(encodables.at(i));
+
+            if (!structure)
+                continue;
+
+            ProtocolFile::makeLineSeparator(output);
+            output += structure->getMapEncodeFunctionString(includeChildren);
+        }
+
+        ProtocolFile::makeLineSeparator(output);
+    }
+
+    // My mapEncode function
+    output += "/*!\n";
+    output += " * Encode the contents of a " + typeName + " structure to a Key:Value string map\n";
+    output += " * \\param _pg_prename is prepended to the key fields in the map\n";
+    output += " * \\param _pg_map is a reference to the map\n";
+    output += " * \\param _pg_user is the structure to encode\n";
+    output += " */\n";
+
+    output += "void mapEncode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, const " + structName + "* _pg_user)\n";
+    output += "{\n";
+
+    if(needsDecodeIterator)
+        output += TAB_IN + "unsigned _pg_i = 0;\n";
+
+    if(needs2ndDecodeIterator)
+        output += TAB_IN + "unsigned _pg_j = 0;\n";
+
+    output += TAB_IN + "QString _pg_prefix = _pg_prename;\n";
+
+    output += TAB_IN + "if(!_pg_prefix.isEmpty() && !_pg_prefix.endsWith(':'))\n";
+    output += TAB_IN + TAB_IN + "_pg_prefix += \":\";\n";
+
+    for(int i=0; i<encodables.length(); i++)
+    {
+        ProtocolFile::makeLineSeparator(output);
+        output += encodables[i]->getMapEncodeString(true);
+    }
+
+    ProtocolFile::makeLineSeparator(output);
+
+    output += "\n";
+    output += "}// mapEncode" + typeName + "\n";
+
+    return output;
+}// ProtocolStructure::getMapEncodeFunctionString
+
+
+/*!
+ * Return the string used for encoding this field to a map
+ * \param isStructureMember should be true to indicate this field is accessed as a member structure
+ * \return the encode string, which may be empty
+ */
+
+QString ProtocolStructure::getMapEncodeString(bool isStructureMember) const
+{
+    QString output;
+    QString access;
+
+    if(getNumberOfDecodeParameters() == 0)
+        return output;
+
+    if(!comment.isEmpty())
+        output += TAB_IN + "// " + comment + "\n";
+
+    std::cout << name.toStdString() << " - getMapEncodeString\n";
+
+    if(isArray())
+    {
+
+        QString spacing = TAB_IN;
+        output += spacing + "for(_pg_i = 0; _pg_i < " + array + "; _pg_i++)\n";
+        spacing += TAB_IN;
+
+        if(isStructureMember)
+        {
+            // The dereference of the array gets us back to the object, but we need the pointer
+            access = "&_pg_user->" + name + "[_pg_i]";
+        }
+        else
+        {
+            access = "&" + name + "[_pg_i]";
+        }
+
+        if(is2dArray())
+        {
+            access += "[_pg_j]";
+            output += spacing + "for(_pg_j = 0; _pg_j < " + array2d + "; _pg_j++)\n";
+            spacing += TAB_IN;
+
+        }// if 2D array of structures
+
+        output += spacing + "_pg_map[<key>] = (array)\n";
+
+
+        //TODO
+    }// if array of structures
+    else
+    {
+        if(isStructureMember)
+        {
+            access = "&pg_user->" + name;
+        }
+        else
+        {
+            access = name;
+        }
+
+        output += TAB_IN + "_pg_map[<key>] = \n";
+
+        //TODO
+    }// else if simple structure, no array
+
+    return output;
+}// ProtocolStructure::getMapEncodeString
+
+
+QString ProtocolStructure::getMapDecodeFunctionPrototype(bool includeChildren) const
+{
+    QString output;
+
+    if(getNumberOfEncodeParameters() == 0)
+    {
+        return output;
+    }
+
+    if(includeChildren)
+    {
+        for(int i = 0; i < encodables.length();  i++)
+        {
+            ProtocolStructure* structure = dynamic_cast<ProtocolStructure*>(encodables.at(i));
+
+            if(!structure)
+                continue;
+
+            ProtocolFile::makeLineSeparator(output);
+
+            output += structure->getMapDecodeFunctionPrototype(includeChildren);
+        }
+
+        ProtocolFile::makeLineSeparator(output);
+    }
+
+    // My mapEncode function
+
+    output += "//! Decode the contents of a " + typeName + " structure from a string Key:Value map\n";
+    output += "void mapDecode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, " + structName + "* _pg_user);\n";
+
+    return output;
+}// ProtocolStructure::getMapDecodeeFunctionPrototype
+
+
+QString ProtocolStructure::getMapDecodeFunctionString(bool includeChildren) const
+{
+    QString output;
+
+    if(getNumberOfDecodeParameters() == 0)
+        return output;
+
+    if(includeChildren)
+    {
+        for(int i = 0; i < encodables.length(); i++)
+        {
+            ProtocolStructure* structure = dynamic_cast<ProtocolStructure*>(encodables.at(i));
+
+            if (!structure)
+                continue;
+
+            ProtocolFile::makeLineSeparator(output);
+            output += structure->getMapDecodeFunctionString(includeChildren);
+        }
+
+        ProtocolFile::makeLineSeparator(output);
+    }
+
+    // My mapEncode function
+    output += "/*!\n";
+    output += " * Decode the contents of a " + typeName + " structure to a Key:Value string map\n";
+    output += " * \\param _pg_prename is prepended to the key fields in the map\n";
+    output += " * \\param _pg_map is a reference to the map\n";
+    output += " * \\param _pg_user is the structure to encode\n";
+    output += " */\n";
+
+    output += "void mapDecode" + typeName + "(const QString& _pg_prename, QMap<QString, QString>& _pg_map, " + structName + "* _pg_user)\n";
+    output += "{\n";
+
+    if(needsDecodeIterator)
+        output += TAB_IN + "unsigned _pg_i = 0;\n";
+
+    if(needs2ndDecodeIterator)
+        output += TAB_IN + "unsigned _pg_j = 0;\n";
+
+    output += TAB_IN + "QString key;\n\n";
+
+    output += TAB_IN + "QString _pg_prefix = _pg_prename;\n";
+
+    output += TAB_IN + "if(!_pg_prefix.isEmpty() && !_pg_prefix.endsWith(':'))\n";
+    output += TAB_IN + TAB_IN + "_pg_prefix += \":\";\n";
+
+    for(int i=0; i<encodables.length(); i++)
+    {
+        ProtocolFile::makeLineSeparator(output);
+        output += encodables[i]->getMapDecodeString(true);
+    }
+
+    ProtocolFile::makeLineSeparator(output);
+
+    output += "\n";
+    output += "}// mapEncode" + typeName + "\n";
+
+    return output;
+}// ProtocolStructure::getMapDecodeFunctionString
+
+
+QString ProtocolStructure::getMapDecodeString(bool isStructureMember) const
+{
+    QString output;
+    QString access;
+
+    if(getNumberOfDecodeParameters() == 0)
+        return output;
+
+    if(!comment.isEmpty())
+        output += TAB_IN + "// " + comment + "\n";
+
+    std::cout << name.toStdString() << " - getMapDecodeString\n";
+
+#warning "Complete this! (Is it even used?)"
+
+    if(isArray())
+    {
+
+        QString spacing = TAB_IN;
+        output += spacing + "for(_pg_i = 0; _pg_i < " + array + "; _pg_i++)\n";
+        spacing += TAB_IN;
+
+        if(isStructureMember)
+        {
+            // The dereference of the array gets us back to the object, but we need the pointer
+            access = "&_pg_user->" + name + "[_pg_i]";
+        }
+        else
+        {
+            access = "&" + name + "[_pg_i]";
+        }
+
+        if(is2dArray())
+        {
+            access += "[_pg_j]";
+            output += spacing + "for(_pg_j = 0; _pg_j < " + array2d + "; _pg_j++)\n";
+            spacing += TAB_IN;
+
+        }// if 2D array of structures
+
+        output += spacing + "decode -> _pg_map[<key>] = (array)\n";
+
+        //TODO
+    }// if array of structures
+    else
+    {
+        if(isStructureMember)
+        {
+            access = "&pg_user->" + name;
+        }
+        else
+        {
+            access = name;
+        }
+
+        output += TAB_IN + "decode -> _pg_map[<key>] = \n";
+
+        //TODO
+    }// else if simple structure, no array
+
+    return output;
+}
+
+
 //! Return the strings that #define initial and variable values
 QString ProtocolStructure::getInitialAndVerifyDefines(bool includeComment) const
 {

--- a/protocolstructure.h
+++ b/protocolstructure.h
@@ -112,6 +112,24 @@ public:
     //! Get the string used for text reading this structure.
     virtual QString getTextReadString(bool isStructureMember) const Q_DECL_OVERRIDE;
 
+    //! Return the string that gives the prototype of the function used to encode this structure to a map
+    QString getMapEncodeFunctionPrototype(bool includeChildren = true) const;
+
+    //! Return the string that gives the function used to encode this structure to a map
+    QString getMapEncodeFunctionString(bool includeChildren = true) const;
+
+    //! Return the string used for map encoding this structure
+    virtual QString getMapEncodeString(bool isStructureMember) const Q_DECL_OVERRIDE;
+
+    //! Return the string that gives the prototype of the function used to decode this structure from a map
+    QString getMapDecodeFunctionPrototype(bool includeChildren = true) const;
+
+    //! Return the string that gives the function used to decode this structure from a map
+    QString getMapDecodeFunctionString(bool includeChildren = true) const;
+
+    //! Return the string used for map decoding this structure
+    virtual QString getMapDecodeString(bool isStructureMember) const Q_DECL_OVERRIDE;
+
     //! Return the string that gives the prototype of the function used to initialize this structure
     QString getSetToInitialValueFunctionPrototype(bool includeChildren = true) const;
 

--- a/protocolstructuremodule.cpp
+++ b/protocolstructuremodule.cpp
@@ -23,7 +23,7 @@ ProtocolStructureModule::ProtocolStructureModule(ProtocolParser* parse, Protocol
     mapEncode(false)
 {
     // These are attributes on top of the normal structure that we support
-    attriblist << "encode" << "decode" << "file" << "deffile" << "verifyfile" << "comparefile" << "printfile" << "mapFile" << "redefine";
+    attriblist << "encode" << "decode" << "file" << "deffile" << "verifyfile" << "comparefile" << "printfile" << "mapfile" << "redefine";
 
     compareSource.setCpp(true);
     compareHeader.setCpp(true);
@@ -615,11 +615,15 @@ void ProtocolStructureModule::createSubStructureFunctions(const ProtocolStructur
 
         if(mapEncode)
         {
-#warning "Complete this"
             mapSource.makeLineSeparator();
             mapSource.write(structure->getMapEncodeFunctionPrototype());
             mapSource.makeLineSeparator();
             mapSource.write(structure->getMapEncodeFunctionString());
+            mapSource.makeLineSeparator();
+            mapSource.makeLineSeparator();
+            mapSource.write(structure->getMapDecodeFunctionPrototype());
+            mapSource.makeLineSeparator();
+            mapSource.write(structure->getMapDecodeFunctionString());
             mapSource.makeLineSeparator();
         }
 
@@ -710,15 +714,14 @@ void ProtocolStructureModule::createTopLevelStructureFunctions(const ProtocolStr
 
     if (mapEncode)
     {
-#warning "Testing true/false for includeChildren"
         mapHeader.makeLineSeparator();
-        mapHeader.write(getMapEncodeFunctionPrototype(true));
+        mapHeader.write(getMapEncodeFunctionPrototype(false));
         mapHeader.makeLineSeparator();
         mapHeader.write(getMapDecodeFunctionPrototype(false));
         mapHeader.makeLineSeparator();
 
         mapSource.makeLineSeparator();
-        mapSource.write(getMapEncodeFunctionString(true));
+        mapSource.write(getMapEncodeFunctionString(false));
         mapSource.makeLineSeparator();
         mapSource.write(getMapDecodeFunctionString(false));
         mapSource.makeLineSeparator();

--- a/protocolstructuremodule.cpp
+++ b/protocolstructuremodule.cpp
@@ -413,8 +413,8 @@ void ProtocolStructureModule::setupFiles(QString moduleName,
     printHeader.writeIncludeDirective(header.fileName());
     printHeader.writeIncludeDirective("QString", QString(), true, false);
     mapHeader.writeIncludeDirective(header.fileName());
-    mapHeader.writeIncludeDirective("QString", QString(), true, false);
-    mapHeader.writeIncludeDirective("QMap", QString(), true, false);
+    mapHeader.writeIncludeDirective("QVariant", QString(), true, false);
+    mapHeader.writeIncludeDirective("string", QString(), true, false);
 
     // The verification details may be spread across multiple files
     QStringList list;

--- a/protocolstructuremodule.cpp
+++ b/protocolstructuremodule.cpp
@@ -19,15 +19,18 @@ ProtocolStructureModule::ProtocolStructureModule(ProtocolParser* parse, Protocol
     encode(true),
     decode(true),
     compare(false),
-    print(false)
+    print(false),
+    mapEncode(false)
 {
     // These are attributes on top of the normal structure that we support
-    attriblist << "encode" << "decode" << "file" << "deffile" << "verifyfile" << "comparefile" << "printfile" << "redefine";
+    attriblist << "encode" << "decode" << "file" << "deffile" << "verifyfile" << "comparefile" << "printfile" << "mapFile" << "redefine";
 
     compareSource.setCpp(true);
     compareHeader.setCpp(true);
     printSource.setCpp(true);
     printHeader.setCpp(true);
+    mapSource.setCpp(true);
+    mapHeader.setCpp(true);
 
 }
 
@@ -51,8 +54,10 @@ void ProtocolStructureModule::clear(void)
     compareSource.clear();
     printHeader.clear();
     printSource.clear();
+    mapSource.clear();
+    mapHeader.clear();
     encode = decode = true;
-    print = compare = false;
+    print = compare = mapEncode = false;
     structfile = &header;
     verifyheaderfile = &header;
     verifysourcefile = &source;
@@ -106,10 +111,14 @@ void ProtocolStructureModule::parse(void)
     QString verifymodulename = ProtocolParser::getAttribute("verifyfile", map);
     QString comparemodulename = ProtocolParser::getAttribute("comparefile", map);
     QString printmodulename = ProtocolParser::getAttribute("printfile", map);
+    QString mapmodulename = ProtocolParser::getAttribute("mapfile", map);
+
     encode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("encode", map));
     decode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("decode", map));
     compare = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("compare", map));
     print = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("print", map));
+    mapEncode = ProtocolParser::isFieldClear(ProtocolParser::getAttribute("map", map));
+
     QString redefinename = ProtocolParser::getAttribute("redefine", map);
 
     // Warnings for users
@@ -132,7 +141,7 @@ void ProtocolStructureModule::parse(void)
     }
 
     // Do the bulk of the file creation and setup
-    setupFiles(moduleName, defheadermodulename, verifymodulename, comparemodulename, printmodulename, true, true, redefines);
+    setupFiles(moduleName, defheadermodulename, verifymodulename, comparemodulename, printmodulename, mapmodulename, true, true, redefines);
 
     // The functions to encoding and ecoding
     createStructureFunctions();
@@ -161,6 +170,13 @@ void ProtocolStructureModule::parse(void)
         printHeader.flush();
     }
 
+    // Only write the map functions if we have map functions to support
+    if(mapEncode)
+    {
+        mapSource.flush();
+        mapHeader.flush();
+    }
+
     // We don't write the verify files to disk if we are not initializing or verifying anything
     if(hasInit() || hasVerify())
     {
@@ -181,7 +197,13 @@ void ProtocolStructureModule::parse(void)
  * \param forceStructureDeclaration should be true to force the declaration of the structure, even if it only has one member
  * \param outputUtilties should be true to output the helper macros
  */
-void ProtocolStructureModule::setupFiles(QString moduleName, QString defheadermodulename, QString verifymodulename, QString comparemodulename, QString printmodulename, bool forceStructureDeclaration, bool outputUtilities, const ProtocolStructureModule* redefines)
+void ProtocolStructureModule::setupFiles(QString moduleName,
+                                         QString defheadermodulename,
+                                         QString verifymodulename,
+                                         QString comparemodulename,
+                                         QString printmodulename,
+                                         QString mapmodulename,
+                                         bool forceStructureDeclaration, bool outputUtilities, const ProtocolStructureModule* redefines)
 {
     // User can provide compare flag, or the file name
     if(!comparemodulename.isEmpty() || !support.globalCompareName.isEmpty())
@@ -190,6 +212,9 @@ void ProtocolStructureModule::setupFiles(QString moduleName, QString defheadermo
     // User can provide print flag, or the file name
     if(!printmodulename.isEmpty() || !support.globalPrintName.isEmpty())
         print = true;
+
+    if(!mapmodulename.isEmpty() || !support.globalMapName.isEmpty())
+        mapEncode = true;
 
     // Must have a structure definition to do compare or print operations (for now)
     if(compare || print || hasVerify() || hasInit())
@@ -207,6 +232,9 @@ void ProtocolStructureModule::setupFiles(QString moduleName, QString defheadermo
 
     compareHeader.setLicenseText(support.licenseText);
     compareSource.setLicenseText(support.licenseText);
+
+    mapHeader.setLicenseText(support.licenseText);
+    mapSource.setLicenseText(support.licenseText);
 
     // The file names
     if(moduleName.isEmpty())
@@ -299,6 +327,38 @@ void ProtocolStructureModule::setupFiles(QString moduleName, QString defheadermo
         }
     }
 
+    if(mapEncode)
+    {
+        if(mapmodulename.isEmpty())
+            mapmodulename = support.globalMapName;
+
+        if(mapmodulename.isEmpty())
+        {
+            mapHeader.setModuleNameAndPath(support.prefix, name + "_map", support.outputpath);
+            mapSource.setModuleNameAndPath(support.prefix, name + "_map", support.outputpath);
+        }
+        else
+        {
+            mapHeader.setModuleNameAndPath(mapmodulename, support.outputpath);
+            mapSource.setModuleNameAndPath(mapmodulename, support.outputpath);
+        }
+
+        mapHeader.makeLineSeparator();
+
+        if(!mapHeader.isAppending())
+        {
+            mapHeader.write("/*!\n");
+            mapHeader.write(" * \\file\n");
+            mapHeader.write(" */\n");
+            mapHeader.write("\n");
+        }
+
+        if(!printSource.isAppending())
+        {
+            mapSource.makeLineSeparator();
+        }
+    }
+
     // Two options here: we may be appending an a-priori existing file, or we may be starting one fresh.
     if(header.isAppending())
     {
@@ -344,7 +404,7 @@ void ProtocolStructureModule::setupFiles(QString moduleName, QString defheadermo
         header.writeIncludeDirective(structfile->fileName());
     }
 
-    // The verify, comparison, and print files needs access to the struct file
+    // The verify, comparison, print, and map files needs access to the struct file
     verifyheaderfile->writeIncludeDirective(structfile->fileName());
     compareHeader.writeIncludeDirective(structfile->fileName());
     compareHeader.writeIncludeDirective(header.fileName());
@@ -352,6 +412,9 @@ void ProtocolStructureModule::setupFiles(QString moduleName, QString defheadermo
     printHeader.writeIncludeDirective(structfile->fileName());
     printHeader.writeIncludeDirective(header.fileName());
     printHeader.writeIncludeDirective("QString", QString(), true, false);
+    mapHeader.writeIncludeDirective(header.fileName());
+    mapHeader.writeIncludeDirective("QString", QString(), true, false);
+    mapHeader.writeIncludeDirective("QMap", QString(), true, false);
 
     // The verification details may be spread across multiple files
     QStringList list;
@@ -550,6 +613,16 @@ void ProtocolStructureModule::createSubStructureFunctions(const ProtocolStructur
             printSource.makeLineSeparator();
         }
 
+        if(mapEncode)
+        {
+#warning "Complete this"
+            mapSource.makeLineSeparator();
+            mapSource.write(structure->getMapEncodeFunctionPrototype());
+            mapSource.makeLineSeparator();
+            mapSource.write(structure->getMapEncodeFunctionString());
+            mapSource.makeLineSeparator();
+        }
+
     }
 
     source.makeLineSeparator();
@@ -633,6 +706,22 @@ void ProtocolStructureModule::createTopLevelStructureFunctions(const ProtocolStr
         printSource.makeLineSeparator();
         printSource.write(getTextReadFunctionString(false));
         printSource.makeLineSeparator();
+    }
+
+    if (mapEncode)
+    {
+#warning "Testing true/false for includeChildren"
+        mapHeader.makeLineSeparator();
+        mapHeader.write(getMapEncodeFunctionPrototype(true));
+        mapHeader.makeLineSeparator();
+        mapHeader.write(getMapDecodeFunctionPrototype(false));
+        mapHeader.makeLineSeparator();
+
+        mapSource.makeLineSeparator();
+        mapSource.write(getMapEncodeFunctionString(true));
+        mapSource.makeLineSeparator();
+        mapSource.write(getMapDecodeFunctionString(false));
+        mapSource.makeLineSeparator();
     }
 
 }// ProtocolStructureModule::createTopLevelStructureFunctions

--- a/protocolstructuremodule.cpp
+++ b/protocolstructuremodule.cpp
@@ -213,7 +213,7 @@ void ProtocolStructureModule::setupFiles(QString moduleName,
     if(!printmodulename.isEmpty() || !support.globalPrintName.isEmpty())
         print = true;
 
-    if(!mapmodulename.isEmpty())
+    if(!mapmodulename.isEmpty() || !support.globalMapName.isEmpty())
         mapEncode = true;
 
     // Must have a structure definition to do compare or print operations (for now)

--- a/protocolstructuremodule.cpp
+++ b/protocolstructuremodule.cpp
@@ -23,7 +23,7 @@ ProtocolStructureModule::ProtocolStructureModule(ProtocolParser* parse, Protocol
     mapEncode(false)
 {
     // These are attributes on top of the normal structure that we support
-    attriblist << "encode" << "decode" << "file" << "deffile" << "verifyfile" << "comparefile" << "printfile" << "mapfile" << "redefine";
+    attriblist << "encode" << "decode" << "file" << "deffile" << "verifyfile" << "comparefile" << "printfile" << "mapfile" << "redefine" << "map";
 
     compareSource.setCpp(true);
     compareHeader.setCpp(true);
@@ -117,7 +117,7 @@ void ProtocolStructureModule::parse(void)
     decode = !ProtocolParser::isFieldClear(ProtocolParser::getAttribute("decode", map));
     compare = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("compare", map));
     print = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("print", map));
-    mapEncode = ProtocolParser::isFieldClear(ProtocolParser::getAttribute("map", map));
+    mapEncode = ProtocolParser::isFieldSet(ProtocolParser::getAttribute("map", map));
 
     QString redefinename = ProtocolParser::getAttribute("redefine", map);
 
@@ -213,7 +213,7 @@ void ProtocolStructureModule::setupFiles(QString moduleName,
     if(!printmodulename.isEmpty() || !support.globalPrintName.isEmpty())
         print = true;
 
-    if(!mapmodulename.isEmpty() || !support.globalMapName.isEmpty())
+    if(!mapmodulename.isEmpty())
         mapEncode = true;
 
     // Must have a structure definition to do compare or print operations (for now)

--- a/protocolstructuremodule.h
+++ b/protocolstructuremodule.h
@@ -87,10 +87,28 @@ public:
     //! Get the path of the source file that encompasses this structure comparison functions
     QString getPrintSourceFilePath(void) const {return printSource.filePath();}
 
+    //! Get the name of the header file that encompasses this structure map functions
+    QString getMapHeaderFileName(void) const {return mapHeader.fileName();}
+
+    //! Get the path of the header file that encompasses this structure map functions
+    QString getMapHeaderFilePath(void) const {return mapHeader.filePath();}
+
+    //! Get the name of the source file that encompasses this structure map functions
+    QString getMapSourceFileName(void) const {return mapSource.fileName();}
+
+    //! Get the path of the source file that encompasses this structure map functions
+    QString getMapSourceFilePath(void) const {return mapSource.filePath();}
+
 protected:
 
     //! Setup the files, which accounts for all the ways the files can be organized for this structure.
-    void setupFiles(QString moduleName, QString defheadermodulename, QString verifymodulename, QString comparemodulename, QString printmodulename, bool forceStructureDeclaration = true, bool outputUtilities = true, const ProtocolStructureModule* redefines = NULL);
+    void setupFiles(QString moduleName,
+                    QString defheadermodulename,
+                    QString verifymodulename,
+                    QString comparemodulename,
+                    QString printmodulename,
+                    QString mapmodulename,
+                    bool forceStructureDeclaration = true, bool outputUtilities = true, const ProtocolStructureModule* redefines = NULL);
 
     //! Issue warnings for the structure module.
     void issueWarnings(const QDomNamedNodeMap& map);
@@ -116,6 +134,8 @@ protected:
     ProtocolHeaderFile compareHeader;       //!< The header file for comparison code (*.h)
     ProtocolSourceFile printSource;         //!< The source file for print code (*.cpp)
     ProtocolHeaderFile printHeader;         //!< The header file for print code (*.h)
+    ProtocolSourceFile mapSource;   //!< The source file for map code (*.cpp)
+    ProtocolHeaderFile mapHeader;   //!< The header file for map code (*.h)
     ProtocolHeaderFile* structfile;         //!< Reference to the file that holds the structure definition
     ProtocolHeaderFile* verifyheaderfile;   //!< Reference to the file that holds the verify prototypes
     ProtocolSourceFile* verifysourcefile;   //!< Reference to the file that holds the verify source code
@@ -125,6 +145,7 @@ protected:
     bool decode;                    //!< True if the decode function is output
     bool compare;                   //!< True if the comparison function is output
     bool print;                     //!< True if the textPrint function is output
+    bool mapEncode;                 //!< True if the mapEncode function is output
 };
 
 #endif // PROTOCOLSTRUCTUREMODULE_H

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -83,6 +83,8 @@ void ProtocolSupport::parse(const QDomNamedNodeMap& map)
     globalCompareName = globalCompareName.left(globalCompareName.indexOf("."));
     globalPrintName = ProtocolParser::getAttribute("printfile", map);
     globalPrintName = globalPrintName.left(globalPrintName.indexOf("."));
+    globalMapName = ProtocolParser::getAttribute("mapfile", map);
+    globalMapName = globalMapName.left(globalMapName.indexOf("."));
 
     // Prefix is not required
     prefix = ProtocolParser::getAttribute("prefix", map);

--- a/protocolsupport.cpp
+++ b/protocolsupport.cpp
@@ -35,6 +35,7 @@ QStringList ProtocolSupport::getAttriblist(void) const
             << "verifyfile"
             << "comparefile"
             << "printfile"
+            << "mapfile"
             << "prefix"
             << "packetStructureSuffix"
             << "packetParameterSuffix"

--- a/protocolsupport.h
+++ b/protocolsupport.h
@@ -28,6 +28,7 @@ public:
     QString globalVerifyName;       //!< Verify file name to be used if a name is not given
     QString globalCompareName;      //!< Comparison file name to be used if a name is not given
     QString globalPrintName;        //!< Print file name to be used if a name is not given
+    QString globalMapName;          //!< Map file name to be used if a name is not given
     QString outputpath;             //!< path to output files to
     QString packetStructureSuffix;  //!< Name to use at end of encode/decode Packet structure functions
     QString packetParameterSuffix;  //!< Name to use at end of encode/decode Packet parameter functions


### PR DESCRIPTION
This PR adds the ability to encode (and decode) a protogen structure to a QMap<QString, QString>, essentially providing a key:value pair encoding for the structure.

_(This is functionality I have been using but previously it was written in Python and an extra script ran through the same .xml file)_

This functionality is _similar_ to the textprint functions but it provides some advantages:

* Greater flexibility in how the data are used (textprint just returns a single string, cannot easily be easily rearranged, appended, pruned, etc)
* Ability to partially load settings files (e.g. settings files can be hand-adjusted to remove any settings that the user does not want to be overwritten
* QMap provides quicker lookup than parsing (repeatedly) across a very long string object
* Provides protection against the (rare) case where you may have a string literal that matches the search part of extractText function

## Example

Here is an example xml descriptor:

```
    <Structure name="SubStruct" file="packets" map="true">
        <Data name="x" inMemoryType="float"/>
        <Data name="y" inMemoryType="float"/>
        <Data name="z" inMemoryType="float"/>
    </Structure>

    <Packet name="ExampleStruct" file="packets" map="true">
        <Data name="uchar" inMemoryType="unsigned8" comment="Unsigned byte"/>
        <Data name="ichar" inMemoryType="signed8" comment="Signed byte"/>
        <Data name="b" inMemoryType="bitfield4" comment="Bitfield (4 bits)"/>
        <Data name="n" inMemoryType="unsigned32" comment="Array size"/>
        <Data name="f" inMemoryType="float" array="10" variableArray="n" comment="Float array (up to 10 items)"/>
        <Data name="s" inMemoryType="string" array="32"/>
        <Data name="a2d" inMemoryType="signed16" array="10" array2d="5" comment="Two dimensional array"/>
        <Data name="sub" struct="SubStruct" comment="Sub structs work too!"/>
    </Packet>
```

And the resulting code:
```
/*!
 * Encode the contents of a Settings_SubStruct_t structure to a Key:Value string map
 * \param _pg_prename is prepended to the key fields in the map
 * \param _pg_map is a reference to the map
 * \param _pg_user is the structure to encode
 */
void mapEncodeSettings_SubStruct_t(const QString& _pg_prename, QMap<QString, QString>& _pg_map, const Settings_SubStruct_t* _pg_user)
{

    _pg_map[_pg_prename + ":x"] = QString::number(_pg_user->x, 'g', 16);

    _pg_map[_pg_prename + ":y"] = QString::number(_pg_user->y, 'g', 16);

    _pg_map[_pg_prename + ":z"] = QString::number(_pg_user->z, 'g', 16);


}// mapEncodeSettings_SubStruct_t

/*!
 * Decode the contents of a Settings_SubStruct_t structure to a Key:Value string map
 * \param _pg_prename is prepended to the key fields in the map
 * \param _pg_map is a reference to the map
 * \param _pg_user is the structure to encode
 */
void mapDecodeSettings_SubStruct_t(const QString& _pg_prename, QMap<QString, QString>& _pg_map, Settings_SubStruct_t* _pg_user)
{
    QString key;

    key = _pg_prename + ":x";
    if(_pg_map.contains(key))
        _pg_user->x = _pg_map[key].toDouble();

    key = _pg_prename + ":y";
    if(_pg_map.contains(key))
        _pg_user->y = _pg_map[key].toDouble();

    key = _pg_prename + ":z";
    if(_pg_map.contains(key))
        _pg_user->z = _pg_map[key].toDouble();


}// mapEncodeSettings_SubStruct_t

/*!
 * Encode the contents of a Settings_ExampleStruct_t structure to a Key:Value string map
 * \param _pg_prename is prepended to the key fields in the map
 * \param _pg_map is a reference to the map
 * \param _pg_user is the structure to encode
 */
void mapEncodeSettings_ExampleStruct_t(const QString& _pg_prename, QMap<QString, QString>& _pg_map, const Settings_ExampleStruct_t* _pg_user)
{
    unsigned _pg_i = 0;
    unsigned _pg_j = 0;

    _pg_map[_pg_prename + ":uchar"] = QString::number(_pg_user->uchar);

    _pg_map[_pg_prename + ":ichar"] = QString::number(_pg_user->ichar);

    _pg_map[_pg_prename + ":b"] = QString::number(_pg_user->b);

    _pg_map[_pg_prename + ":n"] = QString::number(_pg_user->n);

    for(_pg_i = 0; (_pg_i < 10) && (_pg_i < (unsigned)_pg_user->n); _pg_i++)
    {
        _pg_map[_pg_prename + ":f" + "[" + QString::number(_pg_i) + "]"] = QString::number(_pg_user->f[_pg_i], 'g', 16);
    }

    _pg_map[_pg_prename + ":s"] = QString(_pg_user->s);

    for(_pg_i = 0; _pg_i < 10; _pg_i++)
    {
        for(_pg_j = 0; _pg_j < 5; _pg_j++)
        {
            _pg_map[_pg_prename + ":a2d" + "[" + QString::number(_pg_i) + "]" + "[" + QString::number(_pg_j) + "]"] = QString::number(_pg_user->a2d[_pg_i][_pg_j]);
        }
    }

    mapEncodeSettings_SubStruct_t(_pg_prename + ":sub", _pg_map, &_pg_user->sub);


}// mapEncodeSettings_ExampleStruct_t

/*!
 * Decode the contents of a Settings_ExampleStruct_t structure to a Key:Value string map
 * \param _pg_prename is prepended to the key fields in the map
 * \param _pg_map is a reference to the map
 * \param _pg_user is the structure to encode
 */
void mapDecodeSettings_ExampleStruct_t(const QString& _pg_prename, QMap<QString, QString>& _pg_map, Settings_ExampleStruct_t* _pg_user)
{
    unsigned _pg_i = 0;
    unsigned _pg_j = 0;
    QString key;

    key = _pg_prename + ":uchar";
    if(_pg_map.contains(key))
        _pg_user->uchar = _pg_map[key].toUInt();

    key = _pg_prename + ":ichar";
    if(_pg_map.contains(key))
        _pg_user->ichar = _pg_map[key].toInt();

    key = _pg_prename + ":b";
    if(_pg_map.contains(key))
        _pg_user->b = _pg_map[key].toUInt();

    key = _pg_prename + ":n";
    if(_pg_map.contains(key))
        _pg_user->n = _pg_map[key].toUInt();

    for(_pg_i = 0; (_pg_i < 10) && (_pg_i < (unsigned)_pg_user->n); _pg_i++)
    {
        key = _pg_prename + ":f" + "[" + QString::number(_pg_i) + "]";
        if(_pg_map.contains(key))
            _pg_user->f[_pg_i] = _pg_map[key].toDouble();
    }

    key = _pg_prename + ":s";

    if (_pg_map.contains(key))
        strncpy(_pg_user->s, _pg_map[key].toLatin1().constData(), 32);

    for(_pg_i = 0; _pg_i < 10; _pg_i++)
    {
        for(_pg_j = 0; _pg_j < 5; _pg_j++)
        {
            key = _pg_prename + ":a2d" + "[" + QString::number(_pg_i) + "]" + "[" + QString::number(_pg_j) + "]";
            if(_pg_map.contains(key))
                _pg_user->a2d[_pg_i][_pg_j] = _pg_map[key].toInt();
        }
    }

    mapDecodeSettings_SubStruct_t(_pg_prename + ":sub", _pg_map, &_pg_user->sub);


}// mapEncodeSettings_ExampleStruct_t
```