### PR TITLE
[bugfix] - Prevent calls to verify and init functions that do not exist

### DIFF
--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -1984,6 +1984,9 @@ bool ProtocolField::hasInit(void) const
  */
 QString ProtocolField::getVerifyString(bool isStructureMember) const
 {
+    if(!hasVerify())
+        return QString();
+
     // No verify for null or string
     if(inMemoryType.isNull || inMemoryType.isString)
         return QString();
@@ -2551,6 +2554,9 @@ QString ProtocolField::getSetToDefaultsString(bool isStructureMember) const
 QString ProtocolField::getSetInitialValueString(bool isStructureMember) const
 {
     QString output;
+
+    if(!hasInit())
+        return output;
 
     if(inMemoryType.isNull)
         return output;


### PR DESCRIPTION
Previously, there was no check performed to see if a sub-struct had verify or init values. This meant that verify and init function calls were performed on all sub-structures even if they did not have initial or verification values defined.

This patch provides simple checks to prevent this behavior.