### PR TITLE
Force struct declaration when mapEncode routines are defined

### DIFF
--- a/protocolstructuremodule.cpp
+++ b/protocolstructuremodule.cpp
@@ -221,7 +221,7 @@ void ProtocolStructureModule::setupFiles(QString moduleName,
         compare = print = mapEncode = hasverify = hasinit = false;
 
     // Must have a structure definition to do any of these operations
-    if(compare || print || hasverify || hasinit)
+    if(compare || print || mapEncode || hasverify || hasinit)
         forceStructureDeclaration = true;
 
     // The file directive tells us if we are creating a separate file, or if we are appending an existing one


### PR DESCRIPTION
Follow-on from https://github.com/billvaglienti/ProtoGen/issues/78

Structure defs also need to be forced when mapEncode / mapDecode functions are defined for a structure.