### PR TITLE
Lookup by enum comment if a 'title' is not supplied

### DIFF
--- a/enumcreator.cpp
+++ b/enumcreator.cpp
@@ -382,10 +382,18 @@ void EnumCreator::parse(void)
                 continue;
 
             sourceOutput += TAB_IN + "case " + element.getName() + ":\n";
-            if(element.title.isEmpty())
-                sourceOutput += TAB_IN + TAB_IN + "return \"" + element.getLookupName() + "\";\n";
-            else
-                sourceOutput += TAB_IN + TAB_IN + "return \"" + element.title + "\";\n";
+
+            // Title takes first preference, if supplied
+            QString title = element.title;
+
+            // Comment takes second preference, if supplied
+            if (title.isEmpty())
+                title = element.comment;
+
+            if (title.isEmpty())
+                title = element.getLookupName();
+
+            sourceOutput += TAB_IN + TAB_IN + "return \"" + title + "\";\n";
         }
 
         sourceOutput += TAB_IN + "}\n";


### PR DESCRIPTION
The enum lookup currently has the 'lookupTitle' option which is an extra option over 'lookup'.

This PR adds the option to use the 'comment' field as the lookupTitle, if a title is not explicitly supplied.