### PR TITLE
Special casting for boolean fields when encoding to a QVariantMap

### DIFF
--- a/protocolfield.cpp
+++ b/protocolfield.cpp
@@ -3044,6 +3044,11 @@ std::string ProtocolField::getMapEncodeString(void) const
             // Numeric values are automatically converted to correct QVariant types
             if(inMemoryType.isFloat || !printScalerString.empty())
                 output += getEncodeFieldAccess(true) + printScalerString;
+            else if (inMemoryType.isBool && (support.language == ProtocolSupport::c_language || support.language == ProtocolSupport::cpp_language))
+            {
+                // Ensure that boolean types are encoded as unsigned chars
+                output += "(unsigned char) " + getEncodeFieldAccess(true);
+            }
             else
                 output += getEncodeFieldAccess(true);
 


### PR DESCRIPTION
- bool fields are decoded as uint types from a map
- "true" and "false" values are not supported
- Change the encode function to match the decode function

This PR fixed a "bug" which exists between encoding and decoding boolean values from a QVariantMap

- When a boolean value is encoded to a QVariant, the string representation is either `true` or `false`
- When a boolean value is decoded from a QVariant, it *explicitly* attempts to cast it from an integer representation
- Obviously `true` and `false` cannot be converted *from* an integer

e.g. here is how decoding from a map to a bool currently works:

![image](https://user-images.githubusercontent.com/10080325/93159953-b092a180-f752-11ea-92be-c1540bb80aaa.png)

and how the encoding currently works:

![image](https://user-images.githubusercontent.com/10080325/93159981-bc7e6380-f752-11ea-9b98-a7eab5269864.png)

## Changes

So the simple method here is to simply enforce encoding to an integer as follows:

![image](https://user-images.githubusercontent.com/10080325/93160006-ca33e900-f752-11ea-883c-37b94bde682b.png)
