### PR TITLE
Add CMakeLists for building Protogen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.15)
+project(ProtoGen)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Define target
+add_executable(ProtoGen)
+target_sources(ProtoGen
+    PUBLIC
+        prebuiltSources/floatspecial.h
+        protocolfloatspecial.h
+        protocolparser.h
+        protocolpacket.h
+        protocolfield.h
+        enumcreator.h
+        protocolfile.h
+        protocolscaling.h
+        fieldcoding.h
+        encodable.h
+        protocolstructure.h
+        protocolstructuremodule.h
+        protocolsupport.h
+        encodedlength.h
+        shuntingyard.h
+        protocolcode.h
+        protocolbitfield.h
+        protocoldocumentation.h
+        tinyxml/tinyxml2.h
+    PRIVATE
+        main.cpp
+        prebuiltSources/floatspecial.c
+        protocolfloatspecial.cpp
+        protocolparser.cpp
+        protocolpacket.cpp
+        protocolfield.cpp
+        enumcreator.cpp
+        protocolfile.cpp
+        protocolscaling.cpp
+        fieldcoding.cpp
+        encodable.cpp
+        protocolstructure.cpp
+        protocolstructuremodule.cpp
+        protocolsupport.cpp
+        encodedlength.cpp
+        shuntingyard.cpp
+        protocolcode.cpp
+        protocolbitfield.cpp
+        protocoldocumentation.cpp
+        tinyxml/tinyxml2.cpp
+)
+
+target_include_directories(ProtoGen
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tinyxml>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/prebuiltSources>
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(ProtoGen PRIVATE _DEBUG)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,3 +60,6 @@ target_include_directories(ProtoGen
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(ProtoGen PRIVATE _DEBUG)
 endif()
+
+include(GNUInstallDirs)
+install(TARGETS ProtoGen)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ This generates the `./ProtoGen` executable. It may give an error about multimark
 
 ---
 
+Alternative, CMake can be used to build the Protogen executable.
+
+```bash
+cmake -B build
+cmake --build build
+./build/ProtoGen --help
+```
+
 Usage
 =====
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Alternative, CMake can be used to build the Protogen executable.
 ```bash
 cmake -B build
 cmake --build build
-./build/ProtoGen --help
+cmake --install build --prefix install
+./install/bin/ProtoGen --help
 ```
 
 Usage


### PR DESCRIPTION
# Purpose

I want to build Protogen without having QT on my system (just cmake and build-essential) on Ubuntu.

# Details

Add a CMakeLists.txt and example usage in the README. I tested protogen and it resulted in the same output when compiled on Ubuntu 22 as with using qmake/make.

# Follow up

I would like to add a CMake install step that also includes CMake macros so you can
do something like this:
```cmake
find_package(protogen)
protogen_generate(my_doc.xml -no-markdown -no-doxygen)
``` 

That would make protogen super easy to use at build time in CMake. 