### PR TITLE
Set version correctly in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(ProtoGen VERSION 0.0.0)
+project(ProtoGen VERSION 3.6)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/protocolparser.cpp
+++ b/protocolparser.cpp
@@ -14,7 +14,8 @@
 #include <filesystem>
 #include <fstream>
 
-// The version of the protocol generator is set here
+// The version of the protocol generator is set here.
+// This should match CMakeLists.txt.
 const std::string ProtocolParser::genVersion = "3.6.k";
 
 /*!


### PR DESCRIPTION
# Purpose

Make the version in CMake match the source code.

# Details

CMake expects major.minor.patch, where each is a number. Because ProtoGen uses number.number.alpha, this is not allowed in CMake, so I stripped off the patch and only set major.minor.

Now, you can call `find_package(Protogen 3.6 CONFIG)`
Later, with new versions, you will be able to assert a minimum version when finding the generator.